### PR TITLE
configs/tsimx6: Bumped kernel to v5.10.170.6-ts

### DIFF
--- a/configs/tsimx6_debian_11_minimal_defconfig
+++ b/configs/tsimx6_debian_11_minimal_defconfig
@@ -1,6 +1,6 @@
 CONFIG_DS_PACKAGELIST="debian_11_minimum.txt"
 CONFIG_DS_KERNEL_PROVIDER_GIT_URL="https://github.com/embeddedTS/linux-lts.git"
-CONFIG_DS_KERNEL_PROVIDER_GIT_VERSION="v5.10.170.4-ts"
+CONFIG_DS_KERNEL_PROVIDER_GIT_VERSION="v5.10.170.6-ts"
 CONFIG_DS_KERNEL_DEFCONFIG="tsimx6_minimal_defconfig"
 CONFIG_DS_KERNEL_INSTALL_DEVICETREE_FILESYSTEM="imx6dl-ts4900-14 imx6dl-ts4900-2 imx6dl-ts4900 imx6dl-ts7970 imx6dl-ts7990-lxd imx6dl-ts7990-lxd-revb imx6dl-ts7990-microtips imx6dl-ts7990-microtips-revb imx6dl-ts7990-okaya imx6dl-ts7990-okaya-revb imx6q-ts4900-14 imx6q-ts4900-2 imx6q-ts4900 imx6q-ts7970 imx6q-ts7990-lxd imx6q-ts7990-lxd-revb imx6q-ts7990-microtips imx6q-ts7990-microtips-revb imx6q-ts7990-okaya imx6q-ts7990-okaya-revb"
 CONFIG_DS_KERNEL_INSTALL_UIMAGE_FILESYSTEM=y

--- a/configs/tsimx6_debian_12_headless_defconfig
+++ b/configs/tsimx6_debian_12_headless_defconfig
@@ -1,7 +1,7 @@
 CONFIG_DS_DISTRO_DEBIAN_12=y
 CONFIG_DS_PACKAGELIST="debian_12_headless.txt"
 CONFIG_DS_KERNEL_PROVIDER_GIT_URL="https://github.com/embeddedTS/linux-lts.git"
-CONFIG_DS_KERNEL_PROVIDER_GIT_VERSION="v5.10.170.5-ts"
+CONFIG_DS_KERNEL_PROVIDER_GIT_VERSION="v5.10.170.6-ts"
 CONFIG_DS_KERNEL_DEFCONFIG="tsimx6_defconfig"
 CONFIG_DS_KERNEL_INSTALL_DEVICETREE_FILESYSTEM="imx6dl-ts4900-14 imx6dl-ts4900-2 imx6dl-ts4900 imx6dl-ts7970 imx6dl-ts7990-lxd imx6dl-ts7990-lxd-revb imx6dl-ts7990-microtips imx6dl-ts7990-microtips-revb imx6dl-ts7990-okaya imx6dl-ts7990-okaya-revb imx6q-ts4900-14 imx6q-ts4900-2 imx6q-ts4900 imx6q-ts7970 imx6q-ts7990-lxd imx6q-ts7990-lxd-revb imx6q-ts7990-microtips imx6q-ts7990-microtips-revb imx6q-ts7990-okaya imx6q-ts7990-okaya-revb"
 CONFIG_DS_KERNEL_INSTALL_UIMAGE_FILESYSTEM=y

--- a/configs/tsimx6_debian_12_minimal_defconfig
+++ b/configs/tsimx6_debian_12_minimal_defconfig
@@ -1,7 +1,7 @@
 CONFIG_DS_DISTRO_DEBIAN_12=y
 CONFIG_DS_PACKAGELIST="debian_12_minimum.txt"
 CONFIG_DS_KERNEL_PROVIDER_GIT_URL="https://github.com/embeddedTS/linux-lts.git"
-CONFIG_DS_KERNEL_PROVIDER_GIT_VERSION="v5.10.170.5-ts"
+CONFIG_DS_KERNEL_PROVIDER_GIT_VERSION="v5.10.170.6-ts"
 CONFIG_DS_KERNEL_DEFCONFIG="tsimx6_minimal_defconfig"
 CONFIG_DS_KERNEL_INSTALL_DEVICETREE_FILESYSTEM="imx6dl-ts4900-14 imx6dl-ts4900-2 imx6dl-ts4900 imx6dl-ts7970 imx6dl-ts7990-lxd imx6dl-ts7990-lxd-revb imx6dl-ts7990-microtips imx6dl-ts7990-microtips-revb imx6dl-ts7990-okaya imx6dl-ts7990-okaya-revb imx6q-ts4900-14 imx6q-ts4900-2 imx6q-ts4900 imx6q-ts7970 imx6q-ts7990-lxd imx6q-ts7990-lxd-revb imx6q-ts7990-microtips imx6q-ts7990-microtips-revb imx6q-ts7990-okaya imx6q-ts7990-okaya-revb"
 CONFIG_DS_KERNEL_INSTALL_UIMAGE_FILESYSTEM=y

--- a/configs/tsimx6_debian_12_x11_defconfig
+++ b/configs/tsimx6_debian_12_x11_defconfig
@@ -1,7 +1,7 @@
 CONFIG_DS_DISTRO_DEBIAN_12=y
 CONFIG_DS_PACKAGELIST="debian_12_x11.txt"
 CONFIG_DS_KERNEL_PROVIDER_GIT_URL="https://github.com/embeddedTS/linux-lts.git"
-CONFIG_DS_KERNEL_PROVIDER_GIT_VERSION="v5.10.170.5-ts"
+CONFIG_DS_KERNEL_PROVIDER_GIT_VERSION="v5.10.170.6-ts"
 CONFIG_DS_KERNEL_DEFCONFIG="tsimx6_defconfig"
 CONFIG_DS_KERNEL_INSTALL_DEVICETREE_FILESYSTEM="imx6dl-ts4900-14 imx6dl-ts4900-2 imx6dl-ts4900 imx6dl-ts7970 imx6dl-ts7990-lxd imx6dl-ts7990-lxd-revb imx6dl-ts7990-microtips imx6dl-ts7990-microtips-revb imx6dl-ts7990-okaya imx6dl-ts7990-okaya-revb imx6q-ts4900-14 imx6q-ts4900-2 imx6q-ts4900 imx6q-ts7970 imx6q-ts7990-lxd imx6q-ts7990-lxd-revb imx6q-ts7990-microtips imx6q-ts7990-microtips-revb imx6q-ts7990-okaya imx6q-ts7990-okaya-revb"
 CONFIG_DS_KERNEL_INSTALL_ZIMAGE_FILESYSTEM=y

--- a/configs/tsimx6_ubuntu_22_04_minimal_defconfig
+++ b/configs/tsimx6_ubuntu_22_04_minimal_defconfig
@@ -1,7 +1,7 @@
 CONFIG_DS_DISTRO_UBUNTU_22_04=y
 CONFIG_DS_PACKAGELIST="ubuntu_22.04_minimum.txt"
 CONFIG_DS_KERNEL_PROVIDER_GIT_URL="https://github.com/embeddedTS/linux-lts.git"
-CONFIG_DS_KERNEL_PROVIDER_GIT_VERSION="v5.10.170.4-ts"
+CONFIG_DS_KERNEL_PROVIDER_GIT_VERSION="v5.10.170.6-ts"
 CONFIG_DS_KERNEL_DEFCONFIG="tsimx6_minimal_defconfig"
 CONFIG_DS_KERNEL_INSTALL_DEVICETREE_FILESYSTEM="imx6dl-ts4900-14 imx6dl-ts4900-2 imx6dl-ts4900 imx6dl-ts7970 imx6dl-ts7990-lxd imx6dl-ts7990-lxd-revb imx6dl-ts7990-microtips imx6dl-ts7990-microtips-revb imx6dl-ts7990-okaya imx6dl-ts7990-okaya-revb imx6q-ts4900-14 imx6q-ts4900-2 imx6q-ts4900 imx6q-ts7970 imx6q-ts7990-lxd imx6q-ts7990-lxd-revb imx6q-ts7990-microtips imx6q-ts7990-microtips-revb imx6q-ts7990-okaya imx6q-ts7990-okaya-revb"
 CONFIG_DS_KERNEL_INSTALL_UIMAGE_FILESYSTEM=y

--- a/configs/tsimx6_ubuntu_23_04_headless_defconfig
+++ b/configs/tsimx6_ubuntu_23_04_headless_defconfig
@@ -1,7 +1,7 @@
 CONFIG_DS_DISTRO_UBUNTU_23_04=y
 CONFIG_DS_PACKAGELIST="ubuntu_23.04_headless.txt"
 CONFIG_DS_KERNEL_PROVIDER_GIT_URL="https://github.com/embeddedTS/linux-lts.git"
-CONFIG_DS_KERNEL_PROVIDER_GIT_VERSION="v5.10.170.5-ts"
+CONFIG_DS_KERNEL_PROVIDER_GIT_VERSION="v5.10.170.6-ts"
 CONFIG_DS_KERNEL_DEFCONFIG="tsimx6_defconfig"
 CONFIG_DS_KERNEL_INSTALL_DEVICETREE_FILESYSTEM="imx6dl-ts4900-14 imx6dl-ts4900-2 imx6dl-ts4900 imx6dl-ts7970 imx6dl-ts7990-lxd imx6dl-ts7990-lxd-revb imx6dl-ts7990-microtips imx6dl-ts7990-microtips-revb imx6dl-ts7990-okaya imx6dl-ts7990-okaya-revb imx6q-ts4900-14 imx6q-ts4900-2 imx6q-ts4900 imx6q-ts7970 imx6q-ts7990-lxd imx6q-ts7990-lxd-revb imx6q-ts7990-microtips imx6q-ts7990-microtips-revb imx6q-ts7990-okaya imx6q-ts7990-okaya-revb"
 CONFIG_DS_KERNEL_INSTALL_ZIMAGE_FILESYSTEM=y

--- a/configs/tsimx6_ubuntu_23_04_minimal_defconfig
+++ b/configs/tsimx6_ubuntu_23_04_minimal_defconfig
@@ -1,7 +1,7 @@
 CONFIG_DS_DISTRO_UBUNTU_23_04=y
 CONFIG_DS_PACKAGELIST="ubuntu_23.04_minimum.txt"
 CONFIG_DS_KERNEL_PROVIDER_GIT_URL="https://github.com/embeddedTS/linux-lts.git"
-CONFIG_DS_KERNEL_PROVIDER_GIT_VERSION="v5.10.170.5-ts"
+CONFIG_DS_KERNEL_PROVIDER_GIT_VERSION="v5.10.170.6-ts"
 CONFIG_DS_KERNEL_DEFCONFIG="tsimx6_minimal_defconfig"
 CONFIG_DS_KERNEL_INSTALL_DEVICETREE_FILESYSTEM="imx6dl-ts4900-14 imx6dl-ts4900-2 imx6dl-ts4900 imx6dl-ts7970 imx6dl-ts7990-lxd imx6dl-ts7990-lxd-revb imx6dl-ts7990-microtips imx6dl-ts7990-microtips-revb imx6dl-ts7990-okaya imx6dl-ts7990-okaya-revb imx6q-ts4900-14 imx6q-ts4900-2 imx6q-ts4900 imx6q-ts7970 imx6q-ts7990-lxd imx6q-ts7990-lxd-revb imx6q-ts7990-microtips imx6q-ts7990-microtips-revb imx6q-ts7990-okaya imx6q-ts7990-okaya-revb"
 CONFIG_DS_KERNEL_INSTALL_UIMAGE_FILESYSTEM=y

--- a/configs/tsimx6_ubuntu_23_04_x11_defconfig
+++ b/configs/tsimx6_ubuntu_23_04_x11_defconfig
@@ -1,7 +1,7 @@
 CONFIG_DS_DISTRO_UBUNTU_23_04=y
 CONFIG_DS_PACKAGELIST="ubuntu_23.04_x11.txt"
 CONFIG_DS_KERNEL_PROVIDER_GIT_URL="https://github.com/embeddedTS/linux-lts.git"
-CONFIG_DS_KERNEL_PROVIDER_GIT_VERSION="v5.10.170.5-ts"
+CONFIG_DS_KERNEL_PROVIDER_GIT_VERSION="v5.10.170.6-ts"
 CONFIG_DS_KERNEL_DEFCONFIG="tsimx6_defconfig"
 CONFIG_DS_KERNEL_INSTALL_DEVICETREE_FILESYSTEM="imx6dl-ts4900-14 imx6dl-ts4900-2 imx6dl-ts4900 imx6dl-ts7970 imx6dl-ts7990-lxd imx6dl-ts7990-lxd-revb imx6dl-ts7990-microtips imx6dl-ts7990-microtips-revb imx6dl-ts7990-okaya imx6dl-ts7990-okaya-revb imx6q-ts4900-14 imx6q-ts4900-2 imx6q-ts4900 imx6q-ts7970 imx6q-ts7990-lxd imx6q-ts7990-lxd-revb imx6q-ts7990-microtips imx6q-ts7990-microtips-revb imx6q-ts7990-okaya imx6q-ts7990-okaya-revb"
 CONFIG_DS_KERNEL_INSTALL_ZIMAGE_FILESYSTEM=y


### PR DESCRIPTION
Adds support for TS-TPC-7990 Rev.E
Adds fixes for Gbit ethernet with Micrel phy on the TS-4900 solo