### PR TITLE
Support custom mirrors

### DIFF
--- a/tasks/core/chroot_prep/chroot_prep.sh
+++ b/tasks/core/chroot_prep/chroot_prep.sh
@@ -14,7 +14,8 @@ if [ ! -e "${DS_WORK}/rootfs/dev/null" ]; then
 fi
 
 # Set up a temporary resolv.conf.
-if [ -L "/etc/resolv.conf" ]; then
-    install -d $(dirname $(readlink /etc/resolv.conf))
-    echo "nameserver 1.1.1.1" > /etc/resolv.conf
+if [ -L "${DS_WORK}/rootfs/etc/resolv.conf" ]; then
+    cd ${DS_WORK}/rootfs/etc/
+    install -d $(dirname $(readlink resolv.conf))
+    echo "nameserver 1.1.1.1" > "${DS_WORK}/rootfs/etc/resolv.conf"
 fi

--- a/tasks/core/chroot_prep/chroot_prep.sh
+++ b/tasks/core/chroot_prep/chroot_prep.sh
@@ -19,3 +19,8 @@ if [ -L "${DS_WORK}/rootfs/etc/resolv.conf" ]; then
     install -d $(dirname $(readlink resolv.conf))
     echo "nameserver 1.1.1.1" > "${DS_WORK}/rootfs/etc/resolv.conf"
 fi
+
+# The distro will ship its own sources.list
+if [ -e "${DS_WORK}/rootfs/etc/apt/sources.list.d/multistrap-base.list" ]; then
+    rm "${DS_WORK}/rootfs/etc/apt/sources.list.d/multistrap-base.list"
+fi

--- a/tasks/core/create_multistrap_conf/create_multistrap_conf.sh
+++ b/tasks/core/create_multistrap_conf/create_multistrap_conf.sh
@@ -27,6 +27,10 @@ else
     exit 1
 fi
 
+if [ "$CONFIG_DS_CUSTOM_APT_MIRROR" = "y" ]; then
+	sourceurl="$CONFIG_DS_CUSTOM_APT_URL"
+fi
+
 cat <<EOF > "$MULTISTRAPCONF"
 [General]
 arch=${DS_TARGET_ARCH}

--- a/tasks/core/create_multistrap_conf/create_multistrap_conf.sh
+++ b/tasks/core/create_multistrap_conf/create_multistrap_conf.sh
@@ -38,6 +38,7 @@ debootstrap=Base
 aptsources=Base
 
 [Base]
+omitdebsrc=true
 EOF
 echo -n "packages=" >> "$MULTISTRAPCONF"
 

--- a/tasks/distros/Kconfig
+++ b/tasks/distros/Kconfig
@@ -40,6 +40,26 @@ config DS_DISTRO_UBUNTU_23_04
 
 endchoice
 
+config DS_CUSTOM_APT_MIRROR
+	bool "Override default apt repository"
+	default n
+	help
+	  Override debian/ubuntu repository and select a custom mirror for initial fetch
+
+config DS_CUSTOM_APT_URL
+	string "Custom mirror URL"
+	depends on DS_CUSTOM_APT_MIRROR
+	help
+	  Specify URL for custom mirror for initial fetch
+
+config DS_DISTRO_NO_CACHE
+	bool "Use mirror rather than local cache of packages"
+	default n
+	depends on DS_CUSTOM_APT_MIRROR
+	help
+	  Normally a set of packageslists are pulled down once and cached, but this will disable
+	  the local file cache and pull from the mirror every time
+
 config DS_PACKAGELIST
 	string "Package List"
 	help

--- a/tasks/distros/build.sh
+++ b/tasks/distros/build.sh
@@ -9,7 +9,11 @@ install -d "$INSTALL"
 DISTRO_CACHE_KEY=$(sha256sum $MULTISTRAPCONF | cut -f 1 -d ' ')
 DISTRO_CACHE_KEY="distro-${DS_DISTRO}-${DS_RELEASE}-${DS_TARGET_ARCH}-${DISTRO_CACHE_KEY}"
 
-if ! common/host/fetch_cache_obj.sh "$DISTRO_CACHE_KEY" "$INSTALL"; then
+if [ "$CONFIG_DS_DISTRO_NO_CACHE" = "y" ]; then
     /usr/sbin/multistrap -f "$MULTISTRAPCONF" -d "$INSTALL"
-    common/host/store_cache_obj.sh "$DISTRO_CACHE_KEY" "$INSTALL"
+else
+    if ! common/host/fetch_cache_obj.sh "$DISTRO_CACHE_KEY" "$INSTALL"; then
+        /usr/sbin/multistrap -f "$MULTISTRAPCONF" -d "$INSTALL"
+        common/host/store_cache_obj.sh "$DISTRO_CACHE_KEY" "$INSTALL"
+    fi
 fi

--- a/tasks/distros/debian/bookworm/files/debian.sources
+++ b/tasks/distros/debian/bookworm/files/debian.sources
@@ -1,0 +1,7 @@
+Types: deb
+# http://snapshot.debian.org/archive/debian/20230703T000000Z
+URIs: http://deb.debian.org/debian
+Suites: bookworm bookworm-updates
+Components: main
+Signed-By: /usr/share/keyrings/debian-archive-keyring.gpg
+

--- a/tasks/distros/debian/bookworm/manifest.yaml
+++ b/tasks/distros/debian/bookworm/manifest.yaml
@@ -6,3 +6,6 @@ tasks:
     - DS_CORE_MULTISTRAP_CONF
   provides: DS_DISTRO
   description: Fetching Debian 12 distribution
+- cmd: sourceslist.sh
+  cmd_type: host
+  description: Adding sources.list

--- a/tasks/distros/debian/bookworm/sourceslist.sh
+++ b/tasks/distros/debian/bookworm/sourceslist.sh
@@ -1,0 +1,5 @@
+#!/bin/sh -e
+
+COMPONENT_PATH=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd)
+install -d "$DS_OVERLAY/etc/apt/sources.list.d/"
+install -m 644 "${COMPONENT_PATH}/files/debian.sources" "$DS_OVERLAY/etc/apt/sources.list.d/debian.sources"

--- a/tasks/distros/debian/bullseye/files/sources.list
+++ b/tasks/distros/debian/bullseye/files/sources.list
@@ -1,0 +1,2 @@
+deb [arch=armhf] http://deb.debian.org/debian bullseye main contrib non-free
+deb-src http://deb.debian.org/debian bullseye main contrib non-free

--- a/tasks/distros/debian/bullseye/manifest.yaml
+++ b/tasks/distros/debian/bullseye/manifest.yaml
@@ -6,4 +6,6 @@ tasks:
     - DS_CORE_MULTISTRAP_CONF
   provides: DS_DISTRO
   description: Fetching Debian 11 distribution
-
+- cmd: sourceslist.sh
+  cmd_type: host
+  description: Adding sources.list

--- a/tasks/distros/debian/bullseye/sourceslist.sh
+++ b/tasks/distros/debian/bullseye/sourceslist.sh
@@ -1,0 +1,5 @@
+#!/bin/sh -e
+
+COMPONENT_PATH=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd)
+install -d "$DS_OVERLAY/etc/apt/"
+install -m 644 "${COMPONENT_PATH}/files/sources.list" "$DS_OVERLAY/etc/apt/sources.list"

--- a/tasks/distros/ubuntu/jammy/files/sources.list
+++ b/tasks/distros/ubuntu/jammy/files/sources.list
@@ -1,0 +1,42 @@
+# See http://help.ubuntu.com/community/UpgradeNotes for how to upgrade to
+# newer versions of the distribution.
+deb http://ports.ubuntu.com/ubuntu-ports/ jammy main restricted
+# deb-src http://ports.ubuntu.com/ubuntu-ports/ jammy main restricted
+
+## Major bug fix updates produced after the final release of the
+## distribution.
+deb http://ports.ubuntu.com/ubuntu-ports/ jammy-updates main restricted
+# deb-src http://ports.ubuntu.com/ubuntu-ports/ jammy-updates main restricted
+
+## N.B. software from this repository is ENTIRELY UNSUPPORTED by the Ubuntu
+## team. Also, please note that software in universe WILL NOT receive any
+## review or updates from the Ubuntu security team.
+deb http://ports.ubuntu.com/ubuntu-ports/ jammy universe
+# deb-src http://ports.ubuntu.com/ubuntu-ports/ jammy universe
+deb http://ports.ubuntu.com/ubuntu-ports/ jammy-updates universe
+# deb-src http://ports.ubuntu.com/ubuntu-ports/ jammy-updates universe
+
+## N.B. software from this repository is ENTIRELY UNSUPPORTED by the Ubuntu
+## team, and may not be under a free licence. Please satisfy yourself as to
+## your rights to use the software. Also, please note that software in
+## multiverse WILL NOT receive any review or updates from the Ubuntu
+## security team.
+deb http://ports.ubuntu.com/ubuntu-ports/ jammy multiverse
+# deb-src http://ports.ubuntu.com/ubuntu-ports/ jammy multiverse
+deb http://ports.ubuntu.com/ubuntu-ports/ jammy-updates multiverse
+# deb-src http://ports.ubuntu.com/ubuntu-ports/ jammy-updates multiverse
+
+## N.B. software from this repository may not have been tested as
+## extensively as that contained in the main release, although it includes
+## newer versions of some applications which may provide useful features.
+## Also, please note that software in backports WILL NOT receive any review
+## or updates from the Ubuntu security team.
+deb http://ports.ubuntu.com/ubuntu-ports/ jammy-backports main restricted universe multiverse
+# deb-src http://ports.ubuntu.com/ubuntu-ports/ jammy-backports main restricted universe multiverse
+
+deb http://ports.ubuntu.com/ubuntu-ports/ jammy-security main restricted
+# deb-src http://ports.ubuntu.com/ubuntu-ports/ jammy-security main restricted
+deb http://ports.ubuntu.com/ubuntu-ports/ jammy-security universe
+# deb-src http://ports.ubuntu.com/ubuntu-ports/ jammy-security universe
+deb http://ports.ubuntu.com/ubuntu-ports/ jammy-security multiverse
+# deb-src http://ports.ubuntu.com/ubuntu-ports/ jammy-security multiverse

--- a/tasks/distros/ubuntu/jammy/manifest.yaml
+++ b/tasks/distros/ubuntu/jammy/manifest.yaml
@@ -6,3 +6,6 @@ tasks:
     - DS_CORE_MULTISTRAP_CONF
   provides: DS_DISTRO
   description: Fetching Ubuntu 22.04 distribution
+- cmd: sourceslist.sh
+  cmd_type: host
+  description: Adding sources.list

--- a/tasks/distros/ubuntu/jammy/sourceslist.sh
+++ b/tasks/distros/ubuntu/jammy/sourceslist.sh
@@ -1,0 +1,5 @@
+#!/bin/sh -e
+
+COMPONENT_PATH=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd)
+install -d "$DS_OVERLAY/etc/apt/"
+install -m 644 "${COMPONENT_PATH}/files/sources.list" "$DS_OVERLAY/etc/apt/sources.list"

--- a/tasks/distros/ubuntu/lunar/files/sources.list
+++ b/tasks/distros/ubuntu/lunar/files/sources.list
@@ -1,0 +1,42 @@
+# See http://help.ubuntu.com/community/UpgradeNotes for how to upgrade to
+# newer versions of the distribution.
+deb http://ports.ubuntu.com/ubuntu-ports/ lunar main restricted
+# deb-src http://ports.ubuntu.com/ubuntu-ports/ lunar main restricted
+
+## Major bug fix updates produced after the final release of the
+## distribution.
+deb http://ports.ubuntu.com/ubuntu-ports/ lunar-updates main restricted
+# deb-src http://ports.ubuntu.com/ubuntu-ports/ lunar-updates main restricted
+
+## N.B. software from this repository is ENTIRELY UNSUPPORTED by the Ubuntu
+## team. Also, please note that software in universe WILL NOT receive any
+## review or updates from the Ubuntu security team.
+deb http://ports.ubuntu.com/ubuntu-ports/ lunar universe
+# deb-src http://ports.ubuntu.com/ubuntu-ports/ lunar universe
+deb http://ports.ubuntu.com/ubuntu-ports/ lunar-updates universe
+# deb-src http://ports.ubuntu.com/ubuntu-ports/ lunar-updates universe
+
+## N.B. software from this repository is ENTIRELY UNSUPPORTED by the Ubuntu
+## team, and may not be under a free licence. Please satisfy yourself as to
+## your rights to use the software. Also, please note that software in
+## multiverse WILL NOT receive any review or updates from the Ubuntu
+## security team.
+deb http://ports.ubuntu.com/ubuntu-ports/ lunar multiverse
+# deb-src http://ports.ubuntu.com/ubuntu-ports/ lunar multiverse
+deb http://ports.ubuntu.com/ubuntu-ports/ lunar-updates multiverse
+# deb-src http://ports.ubuntu.com/ubuntu-ports/ lunar-updates multiverse
+
+## N.B. software from this repository may not have been tested as
+## extensively as that contained in the main release, although it includes
+## newer versions of some applications which may provide useful features.
+## Also, please note that software in backports WILL NOT receive any review
+## or updates from the Ubuntu security team.
+deb http://ports.ubuntu.com/ubuntu-ports/ lunar-backports main restricted universe multiverse
+# deb-src http://ports.ubuntu.com/ubuntu-ports/ lunar-backports main restricted universe multiverse
+
+deb http://ports.ubuntu.com/ubuntu-ports/ lunar-security main restricted
+# deb-src http://ports.ubuntu.com/ubuntu-ports/ lunar-security main restricted
+deb http://ports.ubuntu.com/ubuntu-ports/ lunar-security universe
+# deb-src http://ports.ubuntu.com/ubuntu-ports/ lunar-security universe
+deb http://ports.ubuntu.com/ubuntu-ports/ lunar-security multiverse
+# deb-src http://ports.ubuntu.com/ubuntu-ports/ lunar-security multiverse

--- a/tasks/distros/ubuntu/lunar/manifest.yaml
+++ b/tasks/distros/ubuntu/lunar/manifest.yaml
@@ -6,3 +6,6 @@ tasks:
     - DS_CORE_MULTISTRAP_CONF
   provides: DS_DISTRO
   description: Fetching Ubuntu 23.04 distribution
+- cmd: sourceslist.sh
+  cmd_type: host
+  description: Adding sources.list

--- a/tasks/distros/ubuntu/lunar/sourceslist.sh
+++ b/tasks/distros/ubuntu/lunar/sourceslist.sh
@@ -1,0 +1,5 @@
+#!/bin/sh -e
+
+COMPONENT_PATH=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd)
+install -d "$DS_OVERLAY/etc/apt/"
+install -m 644 "${COMPONENT_PATH}/files/sources.list" "$DS_OVERLAY/etc/apt/sources.list"


### PR DESCRIPTION
This lets us support custom apt sources during the image creation.

This adds: 
DS_CUSTOM_APT_MIRROR
DS_CUSTOM_APT_URL
which turn on the custom mirror and specify the string

DS_DISTRO_NO_CACHE
This is currently only able to turn on when a mirror is set, but this makes it never look at cache and update from the mirror every time.
