### PR TITLE
lib: task: Add proc mount in target rootfs

### DIFF
--- a/common/lib/task.py
+++ b/common/lib/task.py
@@ -80,10 +80,12 @@ class Task:
                 'docker', 'run', '--rm', '-it',
                 '--volume', f'{ds_host_root_path}:/work/',
                 '--workdir', '/work/',
+                '--mount', 'type=bind,src=/proc/,target=/work/work/rootfs/proc',
                 '--env-file', dockerenv,
                 tag, 'chroot', '/work/work/rootfs',
                 '/bin/bash', '-c', '/run_in_chroot'
             ]
+
             subprocess.run(command, check=True)
 
             command = [ 'docker', 'run', '--rm', '-it',

--- a/common/utils/chroot-shell.py
+++ b/common/utils/chroot-shell.py
@@ -33,6 +33,7 @@ for key, value in kconf.syms.items():
 command = [
     'docker', 'run', '-it',
     '--volume', f'{host_root_path}:/work/',
+    '--mount', 'type=bind,src=/proc/,target=/work/work/rootfs/proc',
     '--workdir', '/work/',
     '--env-file', f'{dockerenv}',
     tag, 'chroot', '/work/work/rootfs', '/bin/bash'


### PR DESCRIPTION
Without a proc mount apt-get during certain operations will attempt to close every possible fd number to make sure its file descriptors are closed. This brings build times of images with command-not-found data from several hours to a few minutes.