### PR TITLE
TS-7100-Z UI demo with LVGL support

### DIFF
--- a/common/host/fetch_blob.sh
+++ b/common/host/fetch_blob.sh
@@ -15,8 +15,9 @@ if [ ! -f "$file_path" ]; then
 fi
 
 if [ -z "$sha256sum" ]; then
-    echo "Error! no sha256sum $file_name!"
-    exit 1
+    echo "Skipping checksum! No sha256sum provided for $file_name!"
+    cp "$file_path" "$work_path"
+    exit 0
 fi
 
 if echo "$sha256sum  $file_path" | sha256sum --quiet -c -; then

--- a/tasks/components/Kconfig
+++ b/tasks/components/Kconfig
@@ -38,10 +38,11 @@ source "tasks/components/watchdog/Kconfig"
 source "tasks/components/resize/Kconfig"
 
 menu "Additional Graphical Components"
-source "tasks/components/startx-service/Kconfig"
 menu "Light and Versatile Graphics Library (LVGL)"
 source "tasks/components/liblvgl/Kconfig"
 source "tasks/components/lv_drivers/Kconfig"
 endmenu
+source "tasks/components/startx-service/Kconfig"
+source "tasks/components/ts7100z-lvgl-ui-demo/Kconfig"
 endmenu
 endmenu

--- a/tasks/components/Kconfig
+++ b/tasks/components/Kconfig
@@ -16,6 +16,7 @@ source "tasks/components/ts4900-fpga/Kconfig"
 source "tasks/components/tssupervisorupdate/Kconfig"
 source "tasks/components/ts-uboot-env-configs/Kconfig"
 source "tasks/components/ts-touchscreen-calibration/Kconfig"
+source "tasks/components/udev-rules/Kconfig"
 endmenu
 
 menu "NXP"

--- a/tasks/components/Kconfig
+++ b/tasks/components/Kconfig
@@ -41,6 +41,7 @@ menu "Additional Graphical Components"
 source "tasks/components/startx-service/Kconfig"
 menu "Light and Versatile Graphics Library (LVGL)"
 source "tasks/components/liblvgl/Kconfig"
+source "tasks/components/lv_drivers/Kconfig"
 endmenu
 endmenu
 endmenu

--- a/tasks/components/Kconfig
+++ b/tasks/components/Kconfig
@@ -36,6 +36,11 @@ source "tasks/components/linux-firmware/Kconfig"
 source "tasks/components/distroboot-scripts/Kconfig"
 source "tasks/components/watchdog/Kconfig"
 source "tasks/components/resize/Kconfig"
-source "tasks/components/startx-service/Kconfig"
 
+menu "Additional Graphical Components"
+source "tasks/components/startx-service/Kconfig"
+menu "Light and Versatile Graphics Library (LVGL)"
+source "tasks/components/liblvgl/Kconfig"
+endmenu
+endmenu
 endmenu

--- a/tasks/components/liblvgl/Kconfig
+++ b/tasks/components/liblvgl/Kconfig
@@ -1,0 +1,13 @@
+config DS_COMPONENT_LIBLVGL
+	bool "liblvgl"
+	help
+	  Build and install libraries and header files to support
+	  the Light and Versatile Graphics Library (LVGL). This
+	  requires an externally provided lv_conf.h file to handle
+	  the build configuration.
+
+config DS_COMPONENT_LIBLVGL_LVCONF
+	string "Path to lv_conf.h"
+	depends on DS_COMPONENT_LIBLVGL
+	help
+	  Path to lv_conf.h file used for build configuration

--- a/tasks/components/liblvgl/build.sh
+++ b/tasks/components/liblvgl/build.sh
@@ -1,0 +1,10 @@
+#!/bin/bash -e
+
+SOURCE="$DS_WORK/components/lvgl"
+
+cd "$SOURCE"
+
+mkdir build
+cd build
+cmake .. -DCMAKE_INSTALL_PREFIX="${DS_OVERLAY}/usr" -DBUILD_SHARED_LIBS=TRUE -DCMAKE_TOOLCHAIN_FILE="${CMAKE_CROSS}"
+make install

--- a/tasks/components/liblvgl/fetch.sh
+++ b/tasks/components/liblvgl/fetch.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+SOURCE="$DS_WORK/components/lvgl"
+GITURL="https://github.com/lvgl/lvgl.git"
+GITVERSION="v8.3.9"
+
+install -d "$SOURCE"
+
+common/host/fetch_git.sh "$GITURL" "$GITVERSION" "$SOURCE"
+common/host/fetch_blob.sh "${CONFIG_DS_COMPONENT_LIBLVGL_LVCONF}" "${SOURCE}"

--- a/tasks/components/liblvgl/manifest.yaml
+++ b/tasks/components/liblvgl/manifest.yaml
@@ -1,0 +1,8 @@
+config: DS_COMPONENT_LIBLVGL
+tasks:
+- cmd: build.sh
+  cmd_type: docker
+  description: Building liblvgl
+- cmd: fetch.sh
+  cmd_type: host
+  description: Downloading liblvgl

--- a/tasks/components/lv_drivers/Kconfig
+++ b/tasks/components/lv_drivers/Kconfig
@@ -1,0 +1,21 @@
+config DS_COMPONENT_LV_DRIVERS
+	bool "lv_drivers"
+	depends on DS_COMPONENT_LIBLVGL
+	help
+	  Drivers package for LVGL. This provides a number of interface
+	  routines for things such as libinput, fbdev, wayland, etc. It
+	  builds and installs libraries and header files to the target.
+
+	  This requires LVGL to be enabled and built. This will have
+	  access to lv_conf.h already from LVGL. Additionally, another
+	  configuration file, lv_drv_conf.h, is needed by lv_drivers in
+	  order to configure the build properly.
+
+comment "lv_drivers needs liblvgl"
+	depends on !DS_COMPONENT_LIBLVGL
+
+config DS_COMPONENT_LV_DRIVERS_LVDRVCONF
+	string "Path to lv_drv_conf.h"
+	depends on DS_COMPONENT_LV_DRIVERS
+	help
+	  Path to lv_drv_conf.h file used for build configuration

--- a/tasks/components/lv_drivers/build.sh
+++ b/tasks/components/lv_drivers/build.sh
@@ -1,0 +1,10 @@
+#!/bin/bash -e
+
+SOURCE="$DS_WORK/components/lv_drivers"
+
+cd "$SOURCE"
+
+mkdir build
+cd build
+cmake .. -DCMAKE_INSTALL_PREFIX="${DS_OVERLAY}/usr" -DCMAKE_C_FLAGS="-L${DS_WORK}/components/lvgl/build/lib -I${DS_WORK}/components/ -I${DS_WORK}/components/lvgl/" -DCMAKE_CXX_FLAGS="-L${DS_WORK}/components/lvgl/build/lib -I${DS_WORK}/components/ -I${DS_WORK}/components/lvgl/" -DBUILD_SHARED_LIBS=TRUE -DCMAKE_TOOLCHAIN_FILE="${CMAKE_CROSS}"
+make install

--- a/tasks/components/lv_drivers/fetch.sh
+++ b/tasks/components/lv_drivers/fetch.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+SOURCE="$DS_WORK/components/lv_drivers"
+GITURL="https://github.com/lvgl/lv_drivers.git"
+GITVERSION="v8.3.0"
+
+install -d "$SOURCE"
+
+common/host/fetch_git.sh "$GITURL" "$GITVERSION" "$SOURCE"
+common/host/fetch_blob.sh "${CONFIG_DS_COMPONENT_LV_DRIVERS_LVDRVCONF}" "${SOURCE}/../"

--- a/tasks/components/lv_drivers/manifest.yaml
+++ b/tasks/components/lv_drivers/manifest.yaml
@@ -1,0 +1,10 @@
+config: DS_COMPONENT_LV_DRIVERS
+tasks:
+- cmd: build.sh
+  cmd_type: docker
+  dependencies:
+    - DS_COMPONENT_LIBLVGL
+  description: Building lv_drivers
+- cmd: fetch.sh
+  cmd_type: host
+  description: Downloading lv_drivers

--- a/tasks/components/ts7100z-lvgl-ui-demo/Kconfig
+++ b/tasks/components/ts7100z-lvgl-ui-demo/Kconfig
@@ -1,0 +1,17 @@
+config DS_COMPONENT_TS7100Z_LVGL_UI_DEMO
+	bool "ts7100z-lvgl-ui-demo"
+	depends on DS_COMPONENT_LIBLVGL
+	depends on DS_COMPONENT_LV_DRIVERS
+	help
+	  Simple graphical demo for TS-7100-Z using LVGL
+
+	  Includes the splash-screen image for I/O location reference;
+	  control of the two relays; control of the 3 high-voltage,
+	  low-side switches; feedback of the input path of those same
+	  low-side switches via emulated LEDs; control of the 1 high-voltage,
+	  high-side switch; and a meter display of the 4 0-12 V ADC inputs.
+
+	  libgpiod and libiiod are used for GPIO and ADC control.
+
+comment "ts7100z-lvgl-ui-demo needs liblvgl and lv_drivers"
+	depends on !DS_COMPONENT_LV_DRIVERS

--- a/tasks/components/ts7100z-lvgl-ui-demo/build.sh
+++ b/tasks/components/ts7100z-lvgl-ui-demo/build.sh
@@ -1,0 +1,10 @@
+#!/bin/bash -e
+
+SOURCE="$DS_WORK/components/ts7100z-lvgl-ui-demo"
+
+cd "$SOURCE"
+
+mkdir build
+cd build
+cmake .. -DCMAKE_INSTALL_PREFIX="${DS_OVERLAY}/usr" -DCMAKE_C_FLAGS="-L${DS_WORK}/components/lvgl/build/lib -L${DS_WORK}/components/lv_drivers/build/lib -I${DS_WORK}/components/ -I${DS_WORK}/components/lvgl/ -I${DS_WORK}/components/lv_drivers/" -DCMAKE_CXX_FLAGS="-L${DS_WORK}/components/lvgl/build/lib -L${DS_WORK}/components/lv_drivers/build/lib -I${DS_WORK}/components/ -I${DS_WORK}/components/lvgl/ -I${DS_WORK}/components/lv_drivers/" -DCMAKE_TOOLCHAIN_FILE="${CMAKE_CROSS}"
+make install

--- a/tasks/components/ts7100z-lvgl-ui-demo/fetch.sh
+++ b/tasks/components/ts7100z-lvgl-ui-demo/fetch.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+SOURCE="$DS_WORK/components/ts7100z-lvgl-ui-demo"
+GITURL="https://github.com/embeddedts/ts7100z-lvgl-ui-demo"
+GITVERSION="v1.0.0"
+
+install -d "$SOURCE"
+
+common/host/fetch_git.sh "$GITURL" "$GITVERSION" "$SOURCE"

--- a/tasks/components/ts7100z-lvgl-ui-demo/manifest.yaml
+++ b/tasks/components/ts7100z-lvgl-ui-demo/manifest.yaml
@@ -1,0 +1,14 @@
+config: DS_COMPONENT_TS7100Z_LVGL_UI_DEMO
+tasks:
+- cmd: build.sh
+  cmd_type: docker
+  dependencies:
+    - DS_COMPONENT_LIBLVGL
+    - DS_COMPONENT_LV_DRIVERS
+  description: Building ts7100z-lvgl-ui-demo
+- cmd: fetch.sh
+  cmd_type: host
+  description: Downloading ts7100z-lvgl-ui-demo
+- cmd: packages.sh
+  cmd_type: packagelist
+  description: Adding libinput0 package

--- a/tasks/components/ts7100z-lvgl-ui-demo/packages.sh
+++ b/tasks/components/ts7100z-lvgl-ui-demo/packages.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+echo "libinput10"

--- a/tasks/components/udev-rules/Kconfig
+++ b/tasks/components/udev-rules/Kconfig
@@ -1,0 +1,30 @@
+config DS_COMPONENT_UDEV_RULES
+	bool "Install udev rules scripts"
+
+config DS_COMPONENT_UDEV_RULES_7100_TOUCH
+	depends on DS_COMPONENT_UDEV_RULES
+	bool "udev rules for TS-7100 resistive touschscreen"
+	help
+	  Installs a udev rules file for touchscreen calibration for
+	  TS-7100-Z
+
+config DS_COMPONENT_UDEV_RULES_4900_8390_TOUCH
+	depends on DS_COMPONENT_UDEV_RULES
+	bool "udev rules for TS-TPC-8390-4900 resistive touschscreen"
+	help
+	  Installs a udev rules file for touchscreen calibration for
+	  TS-TPC-8390-4900
+
+config DS_COMPONENT_UDEV_RULES_4900_8950_TOUCH
+	depends on DS_COMPONENT_UDEV_RULES
+	bool "udev rules for TS-TPC-8950-4900 resistive touschscreen"
+	help
+	  Installs a udev rules file for touchscreen calibration for
+	  TS-TPC-8950-4900
+
+config DS_COMPONENT_UDEV_RULES_7990_TOUCH
+	depends on DS_COMPONENT_UDEV_RULES
+	bool "udev rules for TS-TPC-7990 resistive touschscreen"
+	help
+	  Installs a udev rules file for touchscreen calibration for
+	  TS-TPC-7990

--- a/tasks/components/udev-rules/build.sh
+++ b/tasks/components/udev-rules/build.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+if [ "${CONFIG_DS_COMPONENT_UDEV_RULES_4900_8390_TOUCH}" == "y" ]; then
+	install -d "${DS_OVERLAY}/etc/udev/rules.d/"
+	install -m 644 \
+		"${DS_TASK_PATH}/files/99-ts4900-8390-resistive-touchscreen.rules" \
+		"${DS_OVERLAY}/etc/udev/rules.d/"
+fi
+
+if [ "${CONFIG_DS_COMPONENT_UDEV_RULES_4900_8950_TOUCH}" == "y" ]; then
+	install -d "${DS_OVERLAY}/etc/udev/rules.d/"
+	install -m 644 \
+		"${DS_TASK_PATH}/files/99-ts4900-8950-resistive-touchscreen.rules" \
+		"${DS_OVERLAY}/etc/udev/rules.d/"
+fi
+
+if [ "${CONFIG_DS_COMPONENT_UDEV_RULES_7100_TOUCH}" == "y" ]; then
+	install -d "${DS_OVERLAY}/etc/udev/rules.d/"
+	install -m 644 "${DS_TASK_PATH}/files/99-ts7100-resistive-touchscreen.rules" \
+		"${DS_OVERLAY}/etc/udev/rules.d/"
+fi
+
+if [ "${CONFIG_DS_COMPONENT_UDEV_RULES_7990_TOUCH}" == "y" ]; then
+	install -d "${DS_OVERLAY}/etc/udev/rules.d/"
+	install -m 644 "${DS_TASK_PATH}/files/99-ts7990-resistive-touchscreen.rules" \
+		"${DS_OVERLAY}/etc/udev/rules.d/"
+fi

--- a/tasks/components/udev-rules/files/99-ts4900-8390-resistive-touchscreen.rules
+++ b/tasks/components/udev-rules/files/99-ts4900-8390-resistive-touchscreen.rules
@@ -1,0 +1,4 @@
+# TS-4900-8390
+# Note that, this specifically matches the device and SPI bus.
+# If the SPI bus ever changes for some reason, this will no longer match
+ACTION=="add|change", KERNEL=="event[0-9]*", ATTRS{name}=="ADS7843 Touchscreen", ATTRS{phys}=="spi5.0/input[0-9]*", ENV{LIBINPUT_CALIBRATION_MATRIX}="-1.04718565 0 1.02536149 0 -1.092512 1.05010376"

--- a/tasks/components/udev-rules/files/99-ts4900-8950-resistive-touchscreen.rules
+++ b/tasks/components/udev-rules/files/99-ts4900-8950-resistive-touchscreen.rules
@@ -1,0 +1,4 @@
+# TS-4900-8950
+# Note that, this specifically matches the device and SPI bus.
+# If the SPI bus ever changes for some reason, this will no longer match
+ACTION=="add|change", KERNEL=="event[0-9]*", ATTRS{name}=="ADS7846 Touchscreen", ATTRS{phys}=="spi1.1/input[0-9]*", ENV{LIBINPUT_CALIBRATION_MATRIX}="-1.05070527 0 1.02480539 0 -1.09707288 1.04046077"

--- a/tasks/components/udev-rules/files/99-ts7100-resistive-touchscreen.rules
+++ b/tasks/components/udev-rules/files/99-ts7100-resistive-touchscreen.rules
@@ -1,0 +1,4 @@
+# TS-7100-Z
+# Note that, this specifically matches the device and SPI bus.
+# If the SPI bus ever changes for some reason, this will no longer match
+ACTION=="add|change", KERNEL=="event[0-9]*", ATTRS{name}=="ADS7846 Touchscreen", ATTRS{phys}=="spi5.0/input[0-9]*", ENV{LIBINPUT_CALIBRATION_MATRIX}="1.14360133 0.02219533 -0.06783767 -0.01262267 -1.13283667 1.047116"

--- a/tasks/components/udev-rules/files/99-ts7990-resistive-touchscreen.rules
+++ b/tasks/components/udev-rules/files/99-ts7990-resistive-touchscreen.rules
@@ -1,0 +1,4 @@
+# TS-7990
+# Note that, this specifically matches the device and SPI bus.
+# If the SPI bus ever changes for some reason, this will no longer match
+ACTION=="add|change", KERNEL=="event[0-9]*", ATTRS{name}=="ADS7846 Touchscreen", ATTRS{phys}=="spi5.0/input[0-9]*", ENV{LIBINPUT_CALIBRATION_MATRIX}="-1.0515863 0 1.02480729 0 -1.12352838 1.05727788"

--- a/tasks/components/udev-rules/manifest.yaml
+++ b/tasks/components/udev-rules/manifest.yaml
@@ -1,0 +1,5 @@
+config: DS_COMPONENT_UDEV_RULES
+tasks:
+- cmd: build.sh
+  cmd_type: docker
+  description: Installing udev rules

--- a/tasks/distros/debian/bookworm/host-armel-docker/Dockerfile
+++ b/tasks/distros/debian/bookworm/host-armel-docker/Dockerfile
@@ -10,11 +10,11 @@ ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US.UTF-8
 
 # Set up common docker packages
-RUN apt-get update && apt-get install -y autogen automake bash bc bison build-essential bzip2 ca-certificates curl fakeroot file flex git gzip kmod libconfuse-dev libncursesw5-dev libssl-dev libtool lzop lz4 make meson multistrap ncurses-dev pkg-config qemu-user-static rsync runit u-boot-tools vim wget xz-utils
+RUN apt-get update && apt-get install -y autogen automake bash bc bison build-essential bzip2 ca-certificates cmake curl fakeroot file flex git gzip kmod libconfuse-dev libncursesw5-dev libssl-dev libtool lzop lz4 make meson multistrap ncurses-dev pkg-config qemu-user-static rsync runit u-boot-tools vim wget xz-utils
 
 # Install arch specific packages:
 RUN dpkg --add-architecture armel
-RUN apt-get update && apt-get install -y gcc-arm-linux-gnueabi libc6-dev:armel libgpiod-dev:armel
+RUN apt-get update && apt-get install -y g++-arm-linux-gnueabi gcc-arm-linux-gnueabi libc6-dev:armel libgpiod-dev:armel libinput-dev:armel libiio-dev:armel
 
 # Cross compile variables:
 ENV CROSS_COMPILE=arm-linux-gnueabi-
@@ -26,6 +26,13 @@ RUN echo '[binaries]' > /meson.cross \
     && echo "cpp = 'arm-linux-gnueabi-g++'" >> /meson.cross \
     && echo "ar = 'arm-linux-gnueabi-ar'" >> /meson.cross \
     && echo "strip = 'arm-linux-gnueabi-strip'" >> /meson.cross
+ENV CMAKE_CROSS="/cross.cmake"
+RUN echo "set(CMAKE_SYSTEM_NAME Linux)" > /cross.cmake \
+    && echo "set(CMAKE_C_COMPILER arm-linux-gnueabi-gcc)" >> /cross.cmake \
+    && echo "set(CMAKE_CXX_COMPILER arm-linux-gnueabi-g++)" >> /cross.cmake \
+    && echo "set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)" >> /cross.cmake \
+    && echo "set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)" >> /cross.cmake \
+    && echo "set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)" >> /cross.cmake
 
 # Set PS1 to include docker name:
 ENV chrootname armel_debian_bookworm

--- a/tasks/distros/debian/bookworm/host-armhf-docker/Dockerfile
+++ b/tasks/distros/debian/bookworm/host-armhf-docker/Dockerfile
@@ -10,11 +10,11 @@ ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US.UTF-8
 
 # Set up common docker packages
-RUN apt-get update && apt-get install -y autogen automake bash bc bison build-essential bzip2 ca-certificates curl fakeroot file flex git gzip kmod libconfuse-dev libncursesw5-dev libssl-dev libtool lzop lz4 make meson multistrap ncurses-dev pkg-config qemu-user-static rsync runit u-boot-tools vim wget xz-utils
+RUN apt-get update && apt-get install -y autogen automake bash bc bison build-essential bzip2 ca-certificates cmake curl fakeroot file flex git gzip kmod libconfuse-dev libncursesw5-dev libssl-dev libtool lzop lz4 make meson multistrap ncurses-dev pkg-config qemu-user-static rsync runit u-boot-tools vim wget xz-utils
 
 # Install arch specific packages:
 RUN dpkg --add-architecture armhf
-RUN apt-get update && apt-get install -y gcc-arm-linux-gnueabihf libc6-dev:armhf libgpiod-dev:armhf
+RUN apt-get update && apt-get install -y g++-arm-linux-gnueabihf gcc-arm-linux-gnueabihf libc6-dev:armhf libgpiod-dev:armhf libinput-dev:armhf libiio-dev:armhf
 
 # Cross compile variables:
 ENV CROSS_COMPILE=arm-linux-gnueabihf-
@@ -26,6 +26,13 @@ RUN echo '[binaries]' > /meson.cross \
     && echo "cpp = 'arm-linux-gnueabihf-g++'" >> /meson.cross \
     && echo "ar = 'arm-linux-gnueabihf-ar'" >> /meson.cross \
     && echo "strip = 'arm-linux-gnueabihf-strip'" >> /meson.cross
+ENV CMAKE_CROSS="/cross.cmake"
+RUN echo "set(CMAKE_SYSTEM_NAME Linux)" > /cross.cmake \
+    && echo "set(CMAKE_C_COMPILER arm-linux-gnueabihf-gcc)" >> /cross.cmake \
+    && echo "set(CMAKE_CXX_COMPILER arm-linux-gnueabihf-g++)" >> /cross.cmake \
+    && echo "set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)" >> /cross.cmake \
+    && echo "set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)" >> /cross.cmake \
+    && echo "set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)" >> /cross.cmake
 
 # Set PS1 to include docker name:
 ENV chrootname armhf_debian_bookworm

--- a/tasks/distros/debian/bullseye/host-armel-docker/Dockerfile
+++ b/tasks/distros/debian/bullseye/host-armel-docker/Dockerfile
@@ -10,11 +10,11 @@ ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US.UTF-8
 
 # Set up common docker packages
-RUN apt-get update && apt-get install -y autogen automake bash bc bison build-essential bzip2 ca-certificates curl fakeroot file flex git gzip kmod libconfuse-dev libncursesw5-dev libssl-dev libtool lzop lz4 make meson multistrap ncurses-dev pkg-config python qemu-user-static rsync runit u-boot-tools vim wget xz-utils
+RUN apt-get update && apt-get install -y autogen automake bash bc bison build-essential bzip2 ca-certificates cmake curl fakeroot file flex git gzip kmod libconfuse-dev libncursesw5-dev libssl-dev libtool lzop lz4 make meson multistrap ncurses-dev pkg-config python qemu-user-static rsync runit u-boot-tools vim wget xz-utils
 
 # Install arch specific packages:
 RUN dpkg --add-architecture armel
-RUN apt-get update && apt-get install -y gcc-arm-linux-gnueabi libc6-dev:armel libgpiod-dev:armel
+RUN apt-get update && apt-get install -y g++-arm-linux-gnueabi gcc-arm-linux-gnueabi libc6-dev:armel libgpiod-dev:armel libinput-dev:armel libiio-dev:armel
 
 # Cross compile variables:
 ENV CROSS_COMPILE=arm-linux-gnueabi-
@@ -26,6 +26,13 @@ RUN echo '[binaries]' > /meson.cross \
     && echo "cpp = 'arm-linux-gnueabi-g++'" >> /meson.cross \
     && echo "ar = 'arm-linux-gnueabi-ar'" >> /meson.cross \
     && echo "strip = 'arm-linux-gnueabi-strip'" >> /meson.cross
+ENV CMAKE_CROSS="/cross.cmake"
+RUN echo "set(CMAKE_SYSTEM_NAME Linux)" > /cross.cmake \
+    && echo "set(CMAKE_C_COMPILER arm-linux-gnueabi-gcc)" >> /cross.cmake \
+    && echo "set(CMAKE_CXX_COMPILER arm-linux-gnueabi-g++)" >> /cross.cmake \
+    && echo "set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)" >> /cross.cmake \
+    && echo "set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)" >> /cross.cmake \
+    && echo "set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)" >> /cross.cmake
 
 # Set PS1 to include docker name:
 ENV chrootname armel_debian_bullseye

--- a/tasks/distros/debian/bullseye/host-armhf-docker/Dockerfile
+++ b/tasks/distros/debian/bullseye/host-armhf-docker/Dockerfile
@@ -10,11 +10,11 @@ ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US.UTF-8
 
 # Set up common docker packages
-RUN apt-get update && apt-get install -y autogen automake bash bc bison build-essential bzip2 ca-certificates curl fakeroot file flex git gzip kmod libconfuse-dev libncursesw5-dev libssl-dev libtool lzop lz4 make meson multistrap ncurses-dev pkg-config python qemu-user-static rsync runit u-boot-tools vim wget xz-utils
+RUN apt-get update && apt-get install -y autogen automake bash bc bison build-essential bzip2 ca-certificates cmake curl fakeroot file flex git gzip kmod libconfuse-dev libncursesw5-dev libssl-dev libtool lzop lz4 make meson multistrap ncurses-dev pkg-config python qemu-user-static rsync runit u-boot-tools vim wget xz-utils
 
 # Install arch specific packages:
 RUN dpkg --add-architecture armhf
-RUN apt-get update && apt-get install -y gcc-arm-linux-gnueabihf libc6-dev:armhf libgpiod-dev:armhf
+RUN apt-get update && apt-get install -y g++-arm-linux-gnueabihf gcc-arm-linux-gnueabihf libc6-dev:armhf libgpiod-dev:armhf libinput-dev:armhf libiio-dev:armhf
 
 # Cross compile variables:
 ENV CROSS_COMPILE=arm-linux-gnueabihf-
@@ -26,6 +26,13 @@ RUN echo '[binaries]' > /meson.cross \
     && echo "cpp = 'arm-linux-gnueabihf-g++'" >> /meson.cross \
     && echo "ar = 'arm-linux-gnueabihf-ar'" >> /meson.cross \
     && echo "strip = 'arm-linux-gnueabihf-strip'" >> /meson.cross
+ENV CMAKE_CROSS="/cross.cmake"
+RUN echo "set(CMAKE_SYSTEM_NAME Linux)" > /cross.cmake \
+    && echo "set(CMAKE_C_COMPILER arm-linux-gnueabihf-gcc)" >> /cross.cmake \
+    && echo "set(CMAKE_CXX_COMPILER arm-linux-gnueabihf-g++)" >> /cross.cmake \
+    && echo "set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)" >> /cross.cmake \
+    && echo "set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)" >> /cross.cmake \
+    && echo "set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)" >> /cross.cmake
 
 # Set PS1 to include docker name:
 ENV chrootname armhf_debian_bullseye

--- a/tasks/distros/ubuntu/lunar/host-armhf-docker/Dockerfile
+++ b/tasks/distros/ubuntu/lunar/host-armhf-docker/Dockerfile
@@ -10,7 +10,7 @@ ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US.UTF-8
 
 # Set up common docker packages
-RUN apt-get update && apt-get install -y aptitude autogen automake bash bc bison build-essential bzip2 ca-certificates curl fakeroot file flex git gzip kmod libconfuse-dev libncursesw5-dev libssl-dev libtool lzop lz4 make meson multistrap ncurses-dev pkg-config qemu-user-static rsync runit u-boot-tools vim wget xz-utils
+RUN apt-get update && apt-get install -y aptitude autogen automake bash bc bison build-essential bzip2 ca-certificates cmake curl fakeroot file flex git gzip kmod libconfuse-dev libncursesw5-dev libssl-dev libtool lzop lz4 make meson multistrap ncurses-dev pkg-config qemu-user-static rsync runit u-boot-tools vim wget xz-utils
 
 # Ubuntu has to fetch armhf from a different repo using ports.  We update the 
 # existing sources.list to specify the architecture, then install the packages we need
@@ -20,7 +20,7 @@ RUN dpkg --add-architecture armhf
 RUN apt-get update
 # This must be aptitude because it will have to downgrade some packages
 # to install the armhf distribution
-RUN aptitude install -y libgpiod-dev:armhf libc6:armhf libgcc-s1:armhf libstdc++6:armhf gcc-arm-linux-gnueabihf
+RUN aptitude install -y libgpiod-dev:armhf libc6:armhf libgcc-s1:armhf libstdc++6:armhf gcc-arm-linux-gnueabihf g++-arm-linux-gnueabihf libinput-dev:armhf libiio-dev:armhf
 
 # For linux cross compile
 ENV CROSS_COMPILE=arm-linux-gnueabihf-
@@ -32,6 +32,13 @@ RUN echo '[binaries]' > /meson.cross \
     && echo "cpp = 'arm-linux-gnueabihf-g++'" >> /meson.cross \
     && echo "ar = 'arm-linux-gnueabihf-ar'" >> /meson.cross \
     && echo "strip = 'arm-linux-gnueabihf-strip'" >> /meson.cross
+ENV CMAKE_CROSS="/cross.cmake"
+RUN echo "set(CMAKE_SYSTEM_NAME Linux)" > /cross.cmake \
+    && echo "set(CMAKE_C_COMPILER arm-linux-gnueabihf-gcc)" >> /cross.cmake \
+    && echo "set(CMAKE_CXX_COMPILER arm-linux-gnueabihf-g++)" >> /cross.cmake \
+    && echo "set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)" >> /cross.cmake \
+    && echo "set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)" >> /cross.cmake \
+    && echo "set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)" >> /cross.cmake
 
 # Set PS1 to include docker name:
 ENV chrootname armhf_ubuntu_lunar


### PR DESCRIPTION
This PR brings a few things in.

First, supporting features:
- Adds g++, cmake, libinput-dev, and libiio-dev to Debian and Ubuntu Docker containers
- ~~Adds libinput to Debian and Ubuntu headless and x11 packagelists~~
- fetch_blob script no longer fails if no sha256sum is provided, it simply complains loudly.

Then:
- LVGL compiled as a library. This currently installs headers and library files to the target rootfs
- lv_drivers compiled as a library. This also installs headers and library files to the target rootfs
- ts7100z-lvgl-ui-demo added

Additionally:
- Add udev-rules component. This allows for selection of each udev rules file to install to the target. This is needed for proper LVGL operation on the TS-7100-Z as the demo directly draws to the screen and is unable to take advantage of the X11 calibration files for the touchscreen. This should work for both X11 and Wayland moving forward, but needs more testing before rolling this out to other platforms and removing the existing package. This commit includes support for the TS-7100-Z as well as i.MX6 based TS-TPC devices.


I've tested the TS-7100-Z demo using only Debian targets. It would appear the Ubuntu targets have some issue with building the wilc3000 kernel driver.

Additionally, this does not modify any of the existing defconfigs to enable the demo to run automatically on the TS-7100-Z. This is dependent on an engineering discussion how this would be handled moving forward.