### PR TITLE
fix hardcoded python paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ dl/
 cache/
 __pycache__/
 defconfig
+*~
+sandbox/

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ On either distribution, next install distro-seed, the python requirements and ch
 ```
 git clone https://github.com/embeddedTS/distro-seed.git
 cd distro-seed
-pip install -r requirements.txt
+pip3 install --user -r requirements.txt
 make checkdeps # Verifies all execution requirements are met
 ```
 ## Generating a rootfs:

--- a/common/build.py
+++ b/common/build.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import os
 import glob

--- a/common/build.py
+++ b/common/build.py
@@ -21,8 +21,12 @@ parser.add_argument("--plot-deps", action="store_true", help="Graph out dependen
 args = parser.parse_args()
 
 kconf = kconfiglib.Kconfig('Kconfig')
-kconf.load_config('.config')
-
+try:
+    kconf.load_config('.config')
+except kconfiglib._KconfigIOError as exc:
+    sys.stdout.write(str(exc) + "\n")
+    print("Did you run make <defconfig>?")
+    #sys.exit(2)
 kconfig_export_vars(kconf)
 
 DS_HOST_ROOT_PATH = os.environ['DS_HOST_ROOT_PATH']

--- a/common/lib/vars.py
+++ b/common/lib/vars.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import os
 import sys

--- a/common/utils/check.py
+++ b/common/utils/check.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import sys
 import os

--- a/common/utils/chroot-shell.py
+++ b/common/utils/chroot-shell.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import os
 import sys

--- a/common/utils/clean-cache.py
+++ b/common/utils/clean-cache.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import os
 import sys

--- a/common/utils/clean-work.py
+++ b/common/utils/clean-work.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import os
 import sys

--- a/common/utils/docker-shell.py
+++ b/common/utils/docker-shell.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import os
 import sys

--- a/tasks/core/gen_docker_env/gen_docker_env.py
+++ b/tasks/core/gen_docker_env/gen_docker_env.py
@@ -1,7 +1,11 @@
 #!/usr/bin/python3
 
 import os
-import path
+try:
+    import path
+except ModuleNotFoundError:
+    print("This environment does not have all packages listed in requirements.txt.")
+    raise
 import sys
 
 libpath = os.path.dirname(os.environ['DS_HOST_ROOT_PATH'] + '/common/')

--- a/tasks/core/gen_docker_env/gen_docker_env.py
+++ b/tasks/core/gen_docker_env/gen_docker_env.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import os
 try:


### PR DESCRIPTION
Hardcoding `#/usr/bin/python3` forces this tool's dependencies to be installed system-wide. Idiomatic python is to use `#/usr/bin/env python3`.

Likewise, if we're calling `python3`, the `pip` command is more likely to install into the wrong environment than `pip3` would.

This P.R. rolls up a couple of other, minor enhancements.
