### PR TITLE
rootfs_identification: fix md5sums.txt generation

### DIFF
--- a/tasks/core/rootfs_identification/add_version_sums.sh
+++ b/tasks/core/rootfs_identification/add_version_sums.sh
@@ -5,5 +5,6 @@
 
 ROOTFS="${DS_WORK}/rootfs/"
 
-date +"%Y-%m-%d" > ${ROOTFS}/root.version
-find . -type f -print0 | xargs -0 md5sum > ${ROOTFS}/md5sums.txt
+cd "${ROOTFS}"
+date +"%Y-%m-%d" > root.version
+find . -type f \( ! -name md5sums.txt \) -print0 | xargs -0 md5sum > md5sums.txt


### PR DESCRIPTION
The generation of md5sums.txt was previously grabbing every file in the base directory of `distro-seed/`. Change to the rootfs directory first. Also use the builtin `-exec` option of of `find`.