### PR TITLE
packagelist: Switch from ifupdown2 to ifupdown

### DIFF
--- a/packagelist/debian_11_headless.txt
+++ b/packagelist/debian_11_headless.txt
@@ -9,7 +9,7 @@ udev # needed to set up serial console
 vim
 
 # Network configuration
-ifupdown2
+ifupdown
 iproute2
 isc-dhcp-client
 systemd-timesyncd

--- a/packagelist/debian_11_minimum.txt
+++ b/packagelist/debian_11_minimum.txt
@@ -5,6 +5,6 @@ systemd-sysv # needed to provide /sbin/init
 udev # needed to set up serial console
 
 # Network configuration
-ifupdown2 # Provides auto network configuration with /etc/network/interfaces
+ifupdown # Provides auto network configuration with /etc/network/interfaces
 iproute2 # "ip" and other related tools
 isc-dhcp-client # Basic DHCP client

--- a/packagelist/debian_12_headless.txt
+++ b/packagelist/debian_12_headless.txt
@@ -12,7 +12,7 @@ vim
 
 # Network configuration
 ethtool
-ifupdown2
+ifupdown
 iproute2
 isc-dhcp-client
 net-tools

--- a/packagelist/debian_12_minimum.txt
+++ b/packagelist/debian_12_minimum.txt
@@ -7,6 +7,6 @@ udev # needed to set up serial console
 kmod # needed for kernel module management
 
 # Network configuration
-ifupdown2 # Provides auto network configuration with /etc/network/interfaces
+ifupdown # Provides auto network configuration with /etc/network/interfaces
 iproute2 # "ip" and other related tools
 isc-dhcp-client # Basic DHCP client 

--- a/packagelist/debian_12_x11.txt
+++ b/packagelist/debian_12_x11.txt
@@ -12,7 +12,7 @@ vim
 
 # Network configuration
 ethtool
-ifupdown2
+ifupdown
 iproute2
 isc-dhcp-client
 net-tools


### PR DESCRIPTION
ifupdown2 was unintentionally included instead of the traditional package which sources the interfaces.d directory.  Both perform similar functions, but unless debian migrates to ifupdown2 we should use ifupdown.

Resolves #52.