### PR TITLE
non-minimal packagelists need netbase

### DIFF
--- a/packagelist/debian_11_headless.txt
+++ b/packagelist/debian_11_headless.txt
@@ -31,6 +31,7 @@ watchdog
 # Network utilities
 curl
 iputils-ping
+netbase
 openssh-client
 wget
 

--- a/packagelist/debian_12_headless.txt
+++ b/packagelist/debian_12_headless.txt
@@ -45,6 +45,7 @@ file
 bridge-utils
 curl
 iputils-ping
+netbase
 openssh-client
 rsync
 wget

--- a/packagelist/debian_12_x11.txt
+++ b/packagelist/debian_12_x11.txt
@@ -45,6 +45,7 @@ file
 bridge-utils
 curl
 iputils-ping
+netbase
 openssh-client
 rsync
 wget

--- a/packagelist/ubuntu_23.04_headless.txt
+++ b/packagelist/ubuntu_23.04_headless.txt
@@ -43,6 +43,7 @@ file
 bridge-utils
 curl
 iputils-ping
+netbase
 openssh-client
 rsync
 wget

--- a/packagelist/ubuntu_23.04_x11.txt
+++ b/packagelist/ubuntu_23.04_x11.txt
@@ -43,6 +43,7 @@ file
 bridge-utils
 curl
 iputils-ping
+netbase
 openssh-client
 rsync
 wget


### PR DESCRIPTION
Per issue #40 (Add netbase to full images), the `netbase` package is missing from our packagelists. It is required in order to NFS mount anything beyond an NFS-booted rootfs.

I've added it to all non-minimal Debian packagelists. I don't know if Ubuntu needs it, but unless anyone knows, I'd like to get this P.R. in ASAP. It's a bigger time-suck to keep having to remember to enter `apt update && apt install netbase` after an NFS mount attempt errors-out than to just fix it so that the `nfs-common` package (already in these lists) will actually work :-)
