### PR TITLE
Honor CONFIG_DS_COMPONENT_DISTROBOOT_SCRIPTS_INSTALL_SOURCE

### DIFF
--- a/tasks/components/distroboot-scripts/build.sh
+++ b/tasks/components/distroboot-scripts/build.sh
@@ -3,3 +3,7 @@
 install -d "$DS_OVERLAY/boot/"
 mkimage -A arm -T script -C none -n 'boot' \
         -d "${DS_TASK_PATH}/files/boot.source" "${DS_OVERLAY}/boot/boot.scr"
+
+if [[ "${CONFIG_DS_COMPONENT_DISTROBOOT_SCRIPTS_INSTALL_SOURCE}" == 'y' ]]; then
+    install --target-directory="$DS_OVERLAY/boot/" "${DS_TASK_PATH}/files/boot.source"
+fi


### PR DESCRIPTION
The legacy boot script installs its source, but the new distroboot source doesn't and should, given that **the non-minimal 6ul defconfigs** specify `CONFIG_DS_COMPONENT_DISTROBOOT_SCRIPTS_INSTALL_SOURCE=y`.
