### PR TITLE
Add missing debian-seed packages

### DIFF
--- a/packagelist/debian_11_headless.txt
+++ b/packagelist/debian_11_headless.txt
@@ -1,10 +1,12 @@
+## NOTE: Debian 11 support is deprecated.
+
 ## Bare minimum options:
 kmod # Required for kernel module management
 systemd # needed for init system
 systemd-sysv # needed to provide /sbin/init
 udev # needed to set up serial console
 
-## Small package options:
+## Full package options:
 # Text editors
 vim
 
@@ -22,6 +24,8 @@ wpasupplicant
 
 # Base utils
 dbus
+fdisk
+file
 less
 locales
 lsb-release
@@ -47,3 +51,25 @@ usbutils
 
 # Debug utilities
 strace
+
+# Development tools
+autoconf
+automake
+build-essential
+command-not-found
+dialog
+gdb
+git
+libubootenv-tool
+lsof
+meson
+nfs-common
+sqlite3
+xxd
+
+# Development tools - Python
+python3-bluez
+python3-can
+python3-libgpiod
+python3-libiio
+python3-pip

--- a/packagelist/debian_11_minimum.txt
+++ b/packagelist/debian_11_minimum.txt
@@ -1,3 +1,5 @@
+## NOTE: Debian 11 support is deprecated.
+
 ## Bare minimum options:
 kmod # Required for kernel module management
 systemd # needed for init system

--- a/packagelist/debian_12_headless.txt
+++ b/packagelist/debian_12_headless.txt
@@ -9,6 +9,7 @@ udev # needed to set up serial console
 # Text editors
 nano
 vim
+ed
 
 # Network configuration
 ethtool
@@ -32,14 +33,18 @@ bluez-test-tools
 
 # Base utils
 apt-utils
+bsdmainutils
 dbus
+fdisk
+file
 less
 locales
 lsb-release
+man-db
+parted
 psmisc
 sensible-utils
 watchdog
-file
 
 # Network utilities
 bridge-utils
@@ -58,12 +63,13 @@ can-utils
 gpiod
 i2c-tools
 libiio-utils
+lshw
 memtool
 mmc-utils
+pciutils
 picocom
 setserial
 usbutils
-pciutils
 
 # Debug utilities
 strace
@@ -73,10 +79,26 @@ autoconf
 automake
 build-essential
 command-not-found
+dialog
 gdb
 git
-libiio-dev
 libubootenv-tool
 lsof
 meson
 nfs-common
+sqlite3
+xxd
+
+# Development tools - Python
+python3-bluez
+python3-can
+python3-libgpiod
+python3-libiio
+python3-pip
+
+# Development tools - Python
+python3-bluez
+python3-can
+python3-libgpiod
+python3-libiio
+python3-pip

--- a/packagelist/debian_12_x11.txt
+++ b/packagelist/debian_12_x11.txt
@@ -9,6 +9,7 @@ udev # needed to set up serial console
 # Text editors
 nano
 vim
+ed
 
 # Network configuration
 ethtool
@@ -32,14 +33,18 @@ bluez-test-tools
 
 # Base utils
 apt-utils
+bsdmainutils
 dbus
+fdisk
+file
 less
 locales
 lsb-release
+man-db
+parted
 psmisc
 sensible-utils
 watchdog
-file
 
 # Network utilities
 bridge-utils
@@ -58,12 +63,13 @@ can-utils
 gpiod
 i2c-tools
 libiio-utils
+lshw
 memtool
 mmc-utils
+pciutils
 picocom
 setserial
 usbutils
-pciutils
 
 # Debug utilities
 strace
@@ -73,13 +79,22 @@ autoconf
 automake
 build-essential
 command-not-found
+dialog
 gdb
 git
-libiio-dev
 libubootenv-tool
 lsof
 meson
 nfs-common
+sqlite3
+xxd
+
+# Development tools - Python
+python3-bluez
+python3-can
+python3-libgpiod
+python3-libiio
+python3-pip
 
 # DRM packages
 libdrm-etnaviv1

--- a/packagelist/ubuntu_23.04_headless.txt
+++ b/packagelist/ubuntu_23.04_headless.txt
@@ -10,6 +10,7 @@ udev # needed to set up serial console
 # Text editors
 nano
 vim
+ed
 
 # Network configuration
 iproute2 # "ip" and other related tools
@@ -30,14 +31,18 @@ bluez-hcidump
 
 # Base utils
 apt-utils
+bsdmainutils
 dbus
+fdisk
+file
 less
 locales
 lsb-release
+man-db
+parted
 psmisc
 sensible-utils
 watchdog
-file
 
 # Network utilities
 bridge-utils
@@ -56,12 +61,13 @@ can-utils
 gpiod
 i2c-tools
 libiio-utils
+lshw
 memtool
 mmc-utils
+pciutils
 picocom
 setserial
 usbutils
-pciutils
 
 # Debug utilities
 strace
@@ -71,10 +77,19 @@ autoconf
 automake
 build-essential
 command-not-found
+dialog
 gdb
 git
-libiio-dev
 libubootenv-tool
 lsof
 meson
 nfs-common
+sqlite3
+xxd
+
+# Development tools - Python
+python3-bluez
+python3-can
+python3-libgpiod
+python3-libiio
+python3-pip

--- a/packagelist/ubuntu_23.04_x11.txt
+++ b/packagelist/ubuntu_23.04_x11.txt
@@ -10,6 +10,7 @@ udev # needed to set up serial console
 # Text editors
 nano
 vim
+ed
 
 # Network configuration
 iproute2 # "ip" and other related tools
@@ -30,14 +31,18 @@ bluez-hcidump
 
 # Base utils
 apt-utils
+bsdmainutils
 dbus
+fdisk
+file
 less
 locales
 lsb-release
+man-db
+parted
 psmisc
 sensible-utils
 watchdog
-file
 
 # Network utilities
 bridge-utils
@@ -56,12 +61,13 @@ can-utils
 gpiod
 i2c-tools
 libiio-utils
+lshw
 memtool
 mmc-utils
+pciutils
 picocom
 setserial
 usbutils
-pciutils
 
 # Debug utilities
 strace
@@ -71,13 +77,22 @@ autoconf
 automake
 build-essential
 command-not-found
+dialog
 gdb
 git
-libiio-dev
 libubootenv-tool
 lsof
 meson
 nfs-common
+sqlite3
+xxd
+
+# Development tools - Python
+python3-bluez
+python3-can
+python3-libgpiod
+python3-libiio
+python3-pip
 
 # DRM packages
 libdrm-etnaviv1


### PR DESCRIPTION
These packages were shipping on the 7100 and 7180 before transitioning to distro-seed for Debian builds.

The only thing still missing are gpsd and pps utilities. These will be a separate PR because they're a little more complicated to apply to platforms that didn't previously have them (i.e., in terms of config files, if any, like those used on the 7180 family).

I should also add that these were added on the basis of diff'ing the pre-existing package lists, so there may be reason to remove or change redundant entries that appear other ways (by default, pulled in as a dependency, etc.) and don't belong here.

As for packages that are added under one build system but not the other, my approach here is to frown upon keeping all of the supported platforms "equal by hatchet, axe and saw". Minimal builds excepted, obviously.
