### PR TITLE
tasks: downgrade-wpa-hostapd: Fix temp directory

### DIFF
--- a/tasks/image_configuration/downgrade-wpa-hostapd/fetch.sh
+++ b/tasks/image_configuration/downgrade-wpa-hostapd/fetch.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 
-ROOT_DST="${DS_OVERLAY}/tmp/"
+ROOT_DST="${DS_OVERLAY}/tmp/downgrade-wpa-hostapd"
 
 # Debian distros shipping wpasupplicant 2.10 are:
 # Debian 12 (Bookworm)

--- a/tasks/image_configuration/downgrade-wpa-hostapd/install.sh
+++ b/tasks/image_configuration/downgrade-wpa-hostapd/install.sh
@@ -1,7 +1,6 @@
 #!/bin/bash -e
 
-ROOT_DST="/tmp/"
-
+ROOT_DST="/tmp/downgrade-wpa-hostapd/"
 
 if [ "${DS_DISTRO}" == "debian" ]; then
 	LIBSSL_DEB="libssl1.1_1.1.1w-0+deb11u1_armhf.deb"
@@ -45,6 +44,6 @@ if [ "${RES}" -eq 0 ] ; then
 	apt-mark hold libssl1.1
 	apt-mark hold wpasupplicant
 	apt-mark hold hostapd
-
-	rm -r "${ROOT_DST}"
 fi
+
+rm -r "${ROOT_DST}"


### PR DESCRIPTION
Use a mktemp -d directory which can be safely removed, otherwise /tmp/ is removed causing later tasks to fail.