### PR TITLE
image/ssh-regen: Make sure ssh keys are not shipped in rootfs

### DIFF
--- a/tasks/image_configuration/ssh-regen-keys/Kconfig
+++ b/tasks/image_configuration/ssh-regen-keys/Kconfig
@@ -1,7 +1,3 @@
 config DS_REGENERATE_SSH_KEYS
 	default y
-	bool "Regenerate SSH keys on first boot"
-	help
-	  Regenerate SSH keys during first boot. Otherwise if ssh is included
-	  in the image, all images would have the same keys. You should say
-	  'y' here unless ssh is not included in the image.
+	bool


### PR DESCRIPTION
This makes this task mandatory and runs only if sshd is installed.  If it is, it always removes any keys generated during sshd's package installation.  It also sets up the service to generate ssh keys on the next boot.