### PR TITLE
Fix /bin/bash -e usage

### DIFF
--- a/tasks/components/distroboot-scripts/build.sh
+++ b/tasks/components/distroboot-scripts/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -e
 
 install -d "$DS_OVERLAY/boot/"
 mkimage -A arm -T script -C none -n 'boot' \

--- a/tasks/components/liblvgl/fetch.sh
+++ b/tasks/components/liblvgl/fetch.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -e
 
 SOURCE="$DS_WORK/components/lvgl"
 GITURL="https://github.com/lvgl/lvgl.git"

--- a/tasks/components/lv_drivers/fetch.sh
+++ b/tasks/components/lv_drivers/fetch.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -e
 
 SOURCE="$DS_WORK/components/lv_drivers"
 GITURL="https://github.com/lvgl/lv_drivers.git"

--- a/tasks/components/startx-service/install.sh
+++ b/tasks/components/startx-service/install.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -ex
+#!/bin/bash -e
 
 if [ "$CONFIG_DS_XORG_STARTX_SERVICE_NO_DECORATIONS" = "y" ]; then
     WINDOW_MANAGER_COMMAND="matchbox-window-manager -use_cursor no -use_titlebar no &"

--- a/tasks/components/startx-service/packages.sh
+++ b/tasks/components/startx-service/packages.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -e
 
 # If the default "xterm" was left in place, lets make sure that is installed
 if [ "$CONFIG_DS_XORG_STARTX_SERVICE_TARGET" = "xterm" ]; then

--- a/tasks/components/ts-uboot-env-configs/ensure-fw-env-config.sh
+++ b/tasks/components/ts-uboot-env-configs/ensure-fw-env-config.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -e
 #
 # ensure-fw-env-config.sh - auto-create a service to run generate_fw_env_config at boot
 #

--- a/tasks/components/ts-uboot-env-configs/package-list.sh
+++ b/tasks/components/ts-uboot-env-configs/package-list.sh
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/bin/bash -e
 
 echo "u-boot-tools"

--- a/tasks/components/ts7100-utils/fetch.sh
+++ b/tasks/components/ts7100-utils/fetch.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -e
 
 SOURCE="$DS_WORK/components/ts7100-utils/"
 GITURL="https://github.com/embeddedTS/ts7100-utils.git"

--- a/tasks/components/ts7100z-lvgl-ui-demo/fetch.sh
+++ b/tasks/components/ts7100z-lvgl-ui-demo/fetch.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -e
 
 SOURCE="$DS_WORK/components/ts7100z-lvgl-ui-demo"
 GITURL="https://github.com/embeddedts/ts7100z-lvgl-ui-demo"

--- a/tasks/components/ts7100z-lvgl-ui-demo/packages.sh
+++ b/tasks/components/ts7100z-lvgl-ui-demo/packages.sh
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/bin/bash -e
 
 echo "libinput10"

--- a/tasks/components/ts7400v2-utils/fetch.sh
+++ b/tasks/components/ts7400v2-utils/fetch.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -e
 
 SOURCE="$DS_WORK/components/ts7400v2-utils/"
 GITURL="https://github.com/embeddedTS/ts7400v2-utils-linux4.x.git"

--- a/tasks/components/ts7670-utils/fetch.sh
+++ b/tasks/components/ts7670-utils/fetch.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -e
 
 SOURCE="$DS_WORK/components/ts7670-utils/"
 GITURL="https://github.com/embeddedTS/ts7670-utils-linux4.x.git"

--- a/tasks/components/tssupervisorupdate/fetch.sh
+++ b/tasks/components/tssupervisorupdate/fetch.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -e
 
 SOURCE="$DS_WORK/components/tssupervisorupdate/"
 GITURL="https://github.com/embeddedTS/tssupervisorupdate.git"

--- a/tasks/components/udev-rules/build.sh
+++ b/tasks/components/udev-rules/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -e
 
 if [ "${CONFIG_DS_COMPONENT_UDEV_RULES_4900_8390_TOUCH}" == "y" ]; then
 	install -d "${DS_OVERLAY}/etc/udev/rules.d/"

--- a/tasks/components/watchdog/packages.sh
+++ b/tasks/components/watchdog/packages.sh
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/bin/bash -e
 
 echo "watchdog"

--- a/tasks/components/wilc3000-external-module/fetch.sh
+++ b/tasks/components/wilc3000-external-module/fetch.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -e
 
 SOURCE="$DS_WORK/components/wilc3000-external/"
 GITURL="https://github.com/embeddedTS/wilc3000-external-module.git"

--- a/tasks/components/xorg-etnaviv/install.sh
+++ b/tasks/components/xorg-etnaviv/install.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -e
 
 install -d "$DS_OVERLAY/etc/X11/xorg.conf.d/"
 install -m 644 "${DS_TASK_PATH}"/files/*.conf "${DS_OVERLAY}/etc/X11/xorg.conf.d/"

--- a/tasks/core/apt_finish_install/apt_finish_install.sh
+++ b/tasks/core/apt_finish_install/apt_finish_install.sh
@@ -1,8 +1,14 @@
-#!/bin/bash
+#!/bin/bash -e
 
 export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true
 export LC_ALL=C LANGUAGE=C LANG=C
-dpkg --configure -a
+(
+    # This configure is expected to have a few commands that fail configuring. These
+    # will be fixed by apt-get install -f
+    set +e
+    dpkg --configure -a
+    true
+)
 
 if [ "$DS_DISTRO" == "ubuntu" ] && [ "$DS_RELEASE" == "lunar" ]; then
     # Workaround for:

--- a/tasks/core/chroot_clean/chroot_clean.sh
+++ b/tasks/core/chroot_clean/chroot_clean.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -e
 
 # This command runs from the docker environment to clean up anything left from
 # the prep command

--- a/tasks/core/combine_overlays/combine.sh
+++ b/tasks/core/combine_overlays/combine.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -e
 
 ROOTFS="$DS_WORK/rootfs/"
 INSTALL="$DS_WORK/overlays/"

--- a/tasks/core/set_temporary_resolv/set.sh
+++ b/tasks/core/set_temporary_resolv/set.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -e
 
 # Set up a temporary resolv.conf.
 if [ -L "/etc/resolv.conf" ]; then

--- a/tasks/distros/debian/bookworm/sourceslist.sh
+++ b/tasks/distros/debian/bookworm/sourceslist.sh
@@ -1,4 +1,4 @@
-#!/bin/sh -e
+#!/bin/bash -e
 
 install -d "$DS_OVERLAY/etc/apt/sources.list.d/"
 install -m 644 "${DS_TASK_PATH}/files/debian.sources" "$DS_OVERLAY/etc/apt/sources.list.d/debian.sources"

--- a/tasks/distros/debian/bullseye/sourceslist.sh
+++ b/tasks/distros/debian/bullseye/sourceslist.sh
@@ -1,4 +1,4 @@
-#!/bin/sh -e
+#!/bin/bash -e
 
 install -d "$DS_OVERLAY/etc/apt/"
 install -m 644 "${DS_TASK_PATH}/files/sources.list" "$DS_OVERLAY/etc/apt/sources.list"

--- a/tasks/distros/packagelist_append/packages.sh
+++ b/tasks/distros/packagelist_append/packages.sh
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/bin/bash -e
 
 echo "$CONFIG_DS_DISTRO_PACKAGELIST_APPEND"

--- a/tasks/distros/ubuntu/jammy/sourceslist.sh
+++ b/tasks/distros/ubuntu/jammy/sourceslist.sh
@@ -1,4 +1,4 @@
-#!/bin/sh -e
+#!/bin/bash -e
 
 install -d "$DS_OVERLAY/etc/apt/"
 install -m 644 "${DS_TASK_PATH}/files/sources.list" "$DS_OVERLAY/etc/apt/sources.list"

--- a/tasks/distros/ubuntu/lunar/sourceslist.sh
+++ b/tasks/distros/ubuntu/lunar/sourceslist.sh
@@ -1,4 +1,4 @@
-#!/bin/sh -e
+#!/bin/bash -e
 
 install -d "$DS_OVERLAY/etc/apt/"
 install -m 644 "${DS_TASK_PATH}/files/sources.list" "$DS_OVERLAY/etc/apt/sources.list"

--- a/tasks/image_configuration/set-user/packages.sh
+++ b/tasks/image_configuration/set-user/packages.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -e
 
 # Currently the sudo package is always sudo on any ubuntu/debian release
 if [ "$CONFIG_DS_USER_SUDO" = "y" ]; then

--- a/tasks/image_configuration/update-command-not-found/packages.sh
+++ b/tasks/image_configuration/update-command-not-found/packages.sh
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/bin/bash -e
 
 echo "command-not-found"

--- a/tasks/image_configuration/update-command-not-found/update-command-not-found.sh
+++ b/tasks/image_configuration/update-command-not-found/update-command-not-found.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -ex
+#!/bin/bash -e
 
 if [ "$DS_DISTRO" == "ubuntu" ] && [ "$DS_RELEASE" == "lunar" ]; then
         apt-get update

--- a/tasks/kernel/build.sh
+++ b/tasks/kernel/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -e
 
 SOURCE="$DS_WORK/kernel/linux/"
 KBUILD_OUTPUT="$DS_WORK/kernel/linux-kbuild/"


### PR DESCRIPTION
Some scripts were written to use /bin/bash, some /bin/sh, some with -e, some without. This fixes all of them to use /bin/bash -e.  Arguably most don't need bash features, but for consistency this moves to a single intepreter.