### PR TITLE
numpy 2+ is incompatible with current requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 colorama==0.4.6
+numpy<2
 matplotlib==3.7.1
 networkx==2.8.8
 PyYAML==6.0


### PR DESCRIPTION
Without this in a fresh install, the build breaks at runtime.