### PR TITLE
add alsa-utils to provide audio support for imx93 and other platforms that might have use for it

### DIFF
--- a/packagelist/debian_12_headless.txt
+++ b/packagelist/debian_12_headless.txt
@@ -59,6 +59,7 @@ wget
 openssh-server
 
 # Hardware utilities
+alsa-utils
 can-utils
 gpiod
 i2c-tools

--- a/packagelist/debian_12_x11.txt
+++ b/packagelist/debian_12_x11.txt
@@ -59,6 +59,7 @@ wget
 openssh-server
 
 # Hardware utilities
+alsa-utils
 can-utils
 gpiod
 i2c-tools

--- a/packagelist/ubuntu_24.04_headless.txt
+++ b/packagelist/ubuntu_24.04_headless.txt
@@ -57,6 +57,7 @@ wget
 openssh-server
 
 # Hardware utilities
+alsa-utils
 can-utils
 gpiod
 i2c-tools

--- a/packagelist/ubuntu_24.04_x11.txt
+++ b/packagelist/ubuntu_24.04_x11.txt
@@ -57,6 +57,7 @@ wget
 openssh-server
 
 # Hardware utilities
+alsa-utils
 can-utils
 gpiod
 i2c-tools


### PR DESCRIPTION
The `alsa-utils` package provides several standard utilities needed to verify working audio hardware and configuration.

These include `speaker-test`, `arecord`, and `aplay`.

`speaker-test` uses a sample rate of 48000/sec.; `aplay` can play files with varying sample rates, including 8000 (the default saved by `arecord`) and 44100 (standard CD-quality).

Additional commands in this package are useful for audio diagnostics.

I'm not including the `mplayer` package, because other than being brighter than `aplay` at figuring out MP3 files, -- i.e., `aplay` seems to use 8000 samples/s for the 41.1 kHz MP3 files I tested, despite getting 41.1 kHz WAV files right -- it doesn't seem to add anything necessary beyond `aplay`.
