### PR TITLE
ts-uboot-env-configs: re-runnable fw_env.service

### DIFF
--- a/tasks/components/ts-uboot-env-configs/scripts/select_fw_env_config.sh
+++ b/tasks/components/ts-uboot-env-configs/scripts/select_fw_env_config.sh
@@ -52,13 +52,19 @@ if ! ${found} ; then
 # No matching fw_env.config found in ${env_config_dir} to match"
 # this device's COMPATIBLE string (=${COMPATIBLE}).
 #
-# To fix: Place a correct u-boot environment config file named ${COMPATIBLE}.config
-# into ${env_config_dir}"
+# To fix: Place into ${env_config_dir} (or link to one already there)
+# a correct U-Boot environment config file named:
+# 	${COMPATIBLE}.config
+#
+# Then, retry:
+# 	systemctl start fw_env.service
+# "
 EOF
         exit 1
     fi
 fi
 echo "Selected fw_env.config for COMPATIBLE=${COMPATIBLE}: $(basename ${config_path})"
+rm -f /run/fw_env.config
 ln -s ${config_path} /run/fw_env.config
 
 exit 0


### PR DESCRIPTION
This improves the instructions and workflow when booted on a system that cannot find a usable config.

The service could not be run again after being unable to find a suitable config, because `/run/fw_env.config` would already exist after the previous invocation. Removing any pre-existing run-time file before attempting to create the link fixes the problem with re-running the service.

After following the instructions, the service can now be started again to pick up the new config.
