### PR TITLE
packagelist: Add ncurses-term for ncurses text editor support

### DIFF
--- a/packagelist/debian_12_headless.txt
+++ b/packagelist/debian_12_headless.txt
@@ -10,6 +10,8 @@ udev # needed to set up serial console
 nano
 vim
 ed
+# Needed for most terminal based editors:
+ncurses-term
 
 # Network configuration
 ethtool

--- a/packagelist/debian_12_x11.txt
+++ b/packagelist/debian_12_x11.txt
@@ -10,6 +10,8 @@ udev # needed to set up serial console
 nano
 vim
 ed
+# Needed for most terminal based editors:
+ncurses-term
 
 # Network configuration
 ethtool

--- a/packagelist/ubuntu_24.04_headless.txt
+++ b/packagelist/ubuntu_24.04_headless.txt
@@ -11,6 +11,8 @@ udev # needed to set up serial console
 nano
 vim
 ed
+# Needed for most terminal based editors:
+ncurses-term
 
 # Network configuration
 iproute2 # "ip" and other related tools

--- a/packagelist/ubuntu_24.04_x11.txt
+++ b/packagelist/ubuntu_24.04_x11.txt
@@ -11,6 +11,8 @@ udev # needed to set up serial console
 nano
 vim
 ed
+# Needed for most terminal based editors:
+ncurses-term
 
 # Network configuration
 iproute2 # "ip" and other related tools


### PR DESCRIPTION
On newer releases TERM=vt220 by default, which needs the ncurses terminfo database.

This was found from "nano /any/file" and pasting in content which would result in the console appearing to freeze.