### PR TITLE
tasks: ts-uboot-env: Update uboot env location

### DIFF
--- a/tasks/components/ts-uboot-env-configs/files/ts9370-0.config
+++ b/tasks/components/ts-uboot-env-configs/files/ts9370-0.config
@@ -1,3 +1,2 @@
 # Device                # Offset        # Len
-/dev/mmcblk0boot0       0x200000        0x4000
-/dev/mmcblk0boot0       0x204000        0x4000
+/dev/mmcblk0boot0       0x300000        0x4000


### PR DESCRIPTION
uboot env on imx93 was moved from 0x200000 to 0x300000.