### PR TITLE
configs: tsimx6: revert back to 6.6 series kernel

### DIFF
--- a/configs/tsimx6_debian_13_headless_defconfig
+++ b/configs/tsimx6_debian_13_headless_defconfig
@@ -1,7 +1,7 @@
 CONFIG_DS_DISTRO_DEBIAN_13=y
 CONFIG_DS_PACKAGELIST="debian_13_headless.txt"
 CONFIG_DS_KERNEL_PROVIDER_GIT_URL="https://github.com/embeddedTS/linux-lts.git"
-CONFIG_DS_KERNEL_PROVIDER_GIT_VERSION="v6.18.20.2-ts"
+CONFIG_DS_KERNEL_PROVIDER_GIT_VERSION="v6.6.142-ts"
 CONFIG_DS_KERNEL_DEFCONFIG="tsimx6_defconfig"
 CONFIG_DS_KERNEL_INSTALL_DEVICETREE_FILESYSTEM="imx6dl-ts4900-14 imx6dl-ts4900-2 imx6dl-ts4900 imx6dl-ts7970 imx6dl-ts7990-lxd imx6dl-ts7990-lxd-revb imx6dl-ts7990-microtips imx6dl-ts7990-microtips-revb imx6dl-ts7990-okaya imx6dl-ts7990-okaya-revb imx6q-ts4900-14 imx6q-ts4900-2 imx6q-ts4900 imx6q-ts7970 imx6q-ts7990-lxd imx6q-ts7990-lxd-revb imx6q-ts7990-microtips imx6q-ts7990-microtips-revb imx6q-ts7990-okaya imx6q-ts7990-okaya-revb"
 CONFIG_DS_KERNEL_INSTALL_UIMAGE_FILESYSTEM=y

--- a/configs/tsimx6_debian_13_minimal_defconfig
+++ b/configs/tsimx6_debian_13_minimal_defconfig
@@ -1,7 +1,7 @@
 CONFIG_DS_DISTRO_DEBIAN_13=y
 CONFIG_DS_PACKAGELIST="debian_13_minimal.txt"
 CONFIG_DS_KERNEL_PROVIDER_GIT_URL="https://github.com/embeddedTS/linux-lts.git"
-CONFIG_DS_KERNEL_PROVIDER_GIT_VERSION="v6.18.20.2-ts"
+CONFIG_DS_KERNEL_PROVIDER_GIT_VERSION="v6.6.142-ts"
 CONFIG_DS_KERNEL_DEFCONFIG="tsimx6_minimal_defconfig"
 CONFIG_DS_KERNEL_INSTALL_DEVICETREE_FILESYSTEM="imx6dl-ts4900-14 imx6dl-ts4900-2 imx6dl-ts4900 imx6dl-ts7970 imx6dl-ts7990-lxd imx6dl-ts7990-lxd-revb imx6dl-ts7990-microtips imx6dl-ts7990-microtips-revb imx6dl-ts7990-okaya imx6dl-ts7990-okaya-revb imx6q-ts4900-14 imx6q-ts4900-2 imx6q-ts4900 imx6q-ts7970 imx6q-ts7990-lxd imx6q-ts7990-lxd-revb imx6q-ts7990-microtips imx6q-ts7990-microtips-revb imx6q-ts7990-okaya imx6q-ts7990-okaya-revb"
 CONFIG_DS_KERNEL_INSTALL_UIMAGE_FILESYSTEM=y

--- a/configs/tsimx6_debian_13_x11_defconfig
+++ b/configs/tsimx6_debian_13_x11_defconfig
@@ -1,7 +1,7 @@
 CONFIG_DS_DISTRO_DEBIAN_13=y
 CONFIG_DS_PACKAGELIST="debian_13_x11.txt"
 CONFIG_DS_KERNEL_PROVIDER_GIT_URL="https://github.com/embeddedTS/linux-lts.git"
-CONFIG_DS_KERNEL_PROVIDER_GIT_VERSION="v6.18.20.2-ts"
+CONFIG_DS_KERNEL_PROVIDER_GIT_VERSION="v6.6.142-ts"
 CONFIG_DS_KERNEL_DEFCONFIG="tsimx6_defconfig"
 CONFIG_DS_KERNEL_INSTALL_DEVICETREE_FILESYSTEM="imx6dl-ts4900-14 imx6dl-ts4900-2 imx6dl-ts4900 imx6dl-ts7970 imx6dl-ts7990-lxd imx6dl-ts7990-lxd-revb imx6dl-ts7990-microtips imx6dl-ts7990-microtips-revb imx6dl-ts7990-okaya imx6dl-ts7990-okaya-revb imx6q-ts4900-14 imx6q-ts4900-2 imx6q-ts4900 imx6q-ts7970 imx6q-ts7990-lxd imx6q-ts7990-lxd-revb imx6q-ts7990-microtips imx6q-ts7990-microtips-revb imx6q-ts7990-okaya imx6q-ts7990-okaya-revb"
 CONFIG_DS_KERNEL_INSTALL_ZIMAGE_FILESYSTEM=y


### PR DESCRIPTION
There is some still being diagnosed issue with 6.18 that causes issues in i.MX6 CPUs resulting in kernel panics. For now, stick with 6.6 until we can fully resolve the issue.