### PR TITLE
components: ts7553v2-utils: bump to v3.0.1

### DIFF
--- a/tasks/components/ts7553v2-utils/manifest.yaml
+++ b/tasks/components/ts7553v2-utils/manifest.yaml
@@ -1,5 +1,5 @@
 config: DS_COMPONENT_TS7553V2_UTILS
-version: "3.0.0"
+version: "3.0.1"
 tasks:
 - cmd: fetch.sh
   cmd_type: host


### PR DESCRIPTION
Changes to tssilomon to handle power fail under libgpiod2

Change from `v3.0.0` to `v3.0.1` here: https://github.com/embeddedTS/ts7553v2-utils/pull/10