### PR TITLE
tasks: set-user: honor configured root password

### DIFF
--- a/tasks/image_configuration/set-user/users.sh
+++ b/tasks/image_configuration/set-user/users.sh
@@ -8,7 +8,7 @@ else
 fi
 
 if [ -n "$CONFIG_DS_USER_ROOT_PASSWORD" ]; then
-    echo root:password | chpasswd
+    printf 'root:%s\n' "$CONFIG_DS_USER_ROOT_PASSWORD" | chpasswd
 fi
 
 if [ "$CONFIG_DS_USER" = "y" ]; then


### PR DESCRIPTION
- use the configured `CONFIG_DS_USER_ROOT_PASSWORD` when setting root credentials
- use `printf` with a fixed format to safely pass the password to `chpasswd`
