### PR TITLE
check wget and git host requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ The target chroot is the actual root filesystem being produced. Tasks that need 
 * qemu-img
 * xorriso
 * cpio
+* wget
+* git
 * sha256sum
 * python3
 * python3-colorama
@@ -49,12 +51,12 @@ This will run from any x86_64 Linux distribution that supports KVM, QEMU, python
 
 * From Ubuntu/Debian based distros:
 ```
-apt-get update && apt-get install -y qemu-system-x86 qemu-utils xorriso cpio
+apt-get update && apt-get install -y qemu-system-x86 qemu-utils xorriso cpio wget git
 ```
 
 * From Fedora/Redhat based distros:
 ```
-dnf install qemu-system-x86 qemu-img xorriso cpio
+dnf install qemu-system-x86 qemu-img xorriso cpio wget git
 ```
 
 On either distribution, next install distro-seed, the python requirements and check the dependencies:

--- a/common/utils/check.py
+++ b/common/utils/check.py
@@ -117,6 +117,20 @@ else:
     print("cpio is required to repack the Debian installer initrd")
     ret = 1
 
+if check_bin_in_path('wget'):
+    print("Pass: wget available")
+else:
+    print("Fail: wget missing")
+    print("wget is required by distro-seed download tasks")
+    ret = 1
+
+if check_bin_in_path('git'):
+    print("Pass: git available")
+else:
+    print("Fail: git missing")
+    print("git is required by distro-seed source and kernel tasks")
+    ret = 1
+
 if check_bin_in_path('sha256sum'):
     print("Pass: sha256sum available")
 else:


### PR DESCRIPTION
The build and download tasks use wget and git, but make checkdeps did not verify them.

This updates the existing README requirements/install examples and adds executable checks for both tools. No new documentation was added.